### PR TITLE
Supports `@efmt:on` and `@efmt:off` comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,22 @@ $ efmt -h  # or `rebar3 efmt -h`
 $ efmt --help  # or `rebar3 efmt --help`
 ```
 
+### How to keep some areas from being formatted
+
+If you want to keep the style of some areas in your input text,
+please use `@efmt:off` and `@efmt:on` comments as follows:
+
+```erlang
+foo() ->
+    %% @efmt:off
+    LargeList =
+      [1,2,3,...,
+       998,999,1000],
+    %% @efmt:on
+
+    bar(LargeList).
+```
+
 Editor Integrations
 -------------------
 

--- a/src/format/formatter.rs
+++ b/src/format/formatter.rs
@@ -165,13 +165,7 @@ impl Formatter {
         self.ts
             .comments()
             .range(current..)
-            .find(|c| {
-                if let Ok(Directive::FormatOn) = c.text(&self.ts.text()).parse() {
-                    true
-                } else {
-                    false
-                }
-            })
+            .find(|c| matches!(c.text(&self.ts.text()).parse(), Ok(Directive::FormatOn)))
             .map(|c| c.end_position())
             .unwrap_or_else(|| Position::new(self.ts.text().len(), usize::MAX, usize::MAX))
     }

--- a/src/format/formatter.rs
+++ b/src/format/formatter.rs
@@ -143,8 +143,37 @@ impl Formatter {
         // Note that two spaces before trailing comments will be added just before writing them
         // in `Writer::write_trailing_comment()`.
 
+        match comment.text(&self.ts.text()).parse() {
+            Err(()) => {}
+            Ok(Directive::FormatOn) => {
+                log::warn!("Found a `@efmt:on` comment at line {} without a preceeding `@efmt:off` (just ignored).",
+                           comment.start_position().line());
+            }
+            Ok(Directive::FormatOff) => {
+                let position = self.find_format_on_position(comment.end_position());
+                self.add_span(&(comment.start_position(), position));
+                self.add_newline();
+                return;
+            }
+        }
+
         self.add_token(VisibleToken::Comment(comment));
         self.add_newline();
+    }
+
+    fn find_format_on_position(&self, current: Position) -> Position {
+        self.ts
+            .comments()
+            .range(current..)
+            .find(|c| {
+                if let Ok(Directive::FormatOn) = c.text(&self.ts.text()).parse() {
+                    true
+                } else {
+                    false
+                }
+            })
+            .map(|c| c.end_position())
+            .unwrap_or_else(|| Position::new(self.ts.text().len(), usize::MAX, usize::MAX))
     }
 
     pub fn subregion<F>(&mut self, indent: Indent, newline: Newline, f: F)
@@ -452,4 +481,21 @@ pub enum Newline {
     IfTooLong,
     IfTooLongOrMultiLine,
     IfTooLongOrMultiLineParent,
+}
+
+#[derive(Debug)]
+enum Directive {
+    FormatOn,
+    FormatOff,
+}
+
+impl std::str::FromStr for Directive {
+    type Err = ();
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.trim().trim_start_matches(&[' ', '%'][..]) {
+            "@efmt:on" => Ok(Self::FormatOn),
+            "@efmt:off" => Ok(Self::FormatOff),
+            _ => Err(()),
+        }
+    }
 }

--- a/src/format/formatter.rs
+++ b/src/format/formatter.rs
@@ -499,3 +499,45 @@ impl std::str::FromStr for Directive {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::items::Module;
+
+    #[test]
+    fn directives_works() {
+        let texts = [(
+            indoc::indoc! {"
+            foo()->foo.
+
+            %% @efmt:off
+            bar()->bar.
+            %% @efmt:on
+
+            baz()->
+                [1,
+                 %% @efmt:off
+                 2,3,4,
+                 %% @efmt:on
+                 5,6]."},
+            indoc::indoc! {"
+            foo() ->
+                foo.
+
+            %% @efmt:off
+            bar()->bar.
+            %% @efmt:on
+
+            baz() ->
+                [1,
+                 %% @efmt:off
+                 2,3,4,
+                 %% @efmt:on
+                 5, 6].
+            "},
+        )];
+        for (text, expected) in texts {
+            crate::assert_format!(text, expected, Module);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,4 +107,12 @@ macro_rules! assert_format {
         let expected = $text;
         similar_asserts::assert_str_eq!(formatted, expected);
     }};
+
+    ($text:expr, $expected:expr, $item_type:ident) => {{
+        let formatted = crate::Options::new()
+            .max_columns(20)
+            .format_text::<$item_type>(&$text)
+            .unwrap();
+        similar_asserts::assert_str_eq!(formatted, $expected);
+    }};
 }

--- a/src/span.rs
+++ b/src/span.rs
@@ -4,6 +4,10 @@ pub use efmt_derive::Span;
 pub trait Span {
     fn start_position(&self) -> Position;
     fn end_position(&self) -> Position;
+
+    fn text<'a>(&self, s: &'a str) -> &'a str {
+        &s[self.start_position().offset()..self.end_position().offset()]
+    }
 }
 
 impl<T: Span + ?Sized> Span for &T {


### PR DESCRIPTION
Using those comments, you can disable formatting a specific region of your code.

### An example

Original text:
```erlang
foo()->foo.

%% @efmt:off
bar()->bar.
%% @efmt:on

baz()->
    [1,
     %% @efmt:off
     2,3,4,
     %% @efmt:on
     5,6].
```

Format result:
```erlang
foo() ->
    foo.

%% @efmt:off
bar()->bar.
%% @efmt:on

baz() ->
    [1,
     %% @efmt:off
     2,3,4,
     %% @efmt:on
     5, 6].
```

Closes #1 