### PR TITLE
Add `--default-off` option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 
 name: CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   check:

--- a/rebar3_efmt/src/rebar3_efmt_prv.erl
+++ b/rebar3_efmt/src/rebar3_efmt_prv.erl
@@ -73,6 +73,9 @@ opts() ->
      {include_cache_dirs, undefined, "include-cache-dir", string,
       "Where to save the caches for the macro definitions collected during processing "
       "`-include` or `-include_lib` directives [default: .efmt/cache]"},
+     {default_off, undefined, "default-off", string,
+      "Disables formatting by default. "
+      "efmt behaves as if there is a \"% @efmt:off\" comment at the head of the each target file."},
      {files, undefined, undefined, string,
       "Format target files. "
       "If no files are specified and any of `-c`, `-w` or `--show-files` options is specified, "

--- a/src/format/formatter.rs
+++ b/src/format/formatter.rs
@@ -28,6 +28,12 @@ impl Formatter {
         }
     }
 
+    pub fn skip_formatting(&mut self) {
+        let position = self.find_format_on_position(self.next_position);
+        self.add_span(&(self.next_position, position));
+        self.add_newline();
+    }
+
     pub fn add_token(&mut self, token: VisibleToken) {
         let start_position = token.start_position();
         let end_position = token.end_position();
@@ -150,9 +156,8 @@ impl Formatter {
                            comment.start_position().line());
             }
             Ok(Directive::FormatOff) => {
-                let position = self.find_format_on_position(comment.end_position());
-                self.add_span(&(comment.start_position(), position));
-                self.add_newline();
+                self.next_position = comment.start_position();
+                self.skip_formatting();
                 return;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub fn format_text<T: Parse + Format>(text: &str) -> anyhow::Result<String> {
 pub struct Options {
     max_columns: usize,
     include: IncludeOptions,
+    default_off: bool,
 }
 
 impl Default for Options {
@@ -36,6 +37,7 @@ impl Default for Options {
         Self {
             max_columns: Self::DEFAULT_MAX_COLUMNS,
             include: IncludeOptions::default(),
+            default_off: false,
         }
     }
 }
@@ -71,6 +73,11 @@ impl Options {
         self
     }
 
+    pub fn default_off(mut self) -> Self {
+        self.default_off = true;
+        self
+    }
+
     pub fn format_file<T: Parse + Format, P: AsRef<Path>>(self, path: P) -> anyhow::Result<String> {
         let text = std::fs::read_to_string(&path)?;
         let mut tokenizer = erl_tokenize::Tokenizer::new(text);
@@ -90,6 +97,9 @@ impl Options {
         let mut ts = TokenStream::new(tokenizer, self.include);
         let item: T = ts.parse()?;
         let mut formatter = Formatter::new(ts);
+        if self.default_off {
+            formatter.skip_formatting();
+        }
         item.format(&mut formatter);
         let formatted_text = formatter.format(self.max_columns);
         Ok(formatted_text)

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,11 @@ struct Opt {
     #[structopt(long)]
     disable_include_cache: bool,
 
+    /// Disables formatting by default.
+    /// efmt behaves as if there is a "% @efmt:off" comment at the head of the each target file.
+    #[structopt(long)]
+    default_off: bool,
+
     /// Enable profiling by `pprof`. The profile report will be generated in `flamegraph.svg`.
     #[cfg(feature = "pprof")]
     #[structopt(long)]
@@ -104,6 +109,9 @@ impl Opt {
         }
         if self.disable_include {
             format_options = format_options.disable_include();
+        }
+        if self.default_off {
+            format_options = format_options.default_off();
         }
 
         format_options

--- a/src/main.rs
+++ b/src/main.rs
@@ -346,7 +346,7 @@ fn validate_formatted_text<P: AsRef<Path>>(
             Some(Ok(t1)) => t1,
             Some(Err(e)) => {
                 let reason = e.to_string();
-                let reason_end = reason.find(" (").unwrap_or_else(|| reason.len());
+                let reason_end = reason.find(" (").unwrap_or(reason.len());
                 anyhow::bail!(
                     "{}",
                     efmt::error::generate_error_message(

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -73,9 +73,7 @@ impl Error {
 
     fn tokenize_error_message(source: &erl_tokenize::Error, text: &Arc<String>) -> String {
         let source_message = source.to_string();
-        let source_message_end = source_message
-            .find(" (")
-            .unwrap_or_else(|| source_message.len());
+        let source_message_end = source_message.find(" (").unwrap_or(source_message.len());
         crate::error::generate_error_message(
             text,
             source.position().filepath(),


### PR DESCRIPTION
If this option is specified, we need to do add a "% efmt:on" comment to the head of the each target file to enable formatting. 
This option is useful to gradually introduce `efmt` into existing projects.