### PR TITLE
Use the same indent for  adjacent constant values (macros)

### DIFF
--- a/src/format/formatter.rs
+++ b/src/format/formatter.rs
@@ -29,6 +29,10 @@ impl Formatter {
         }
     }
 
+    pub fn token_stream(&self) -> &TokenStream {
+        &self.ts
+    }
+
     pub fn skip_formatting(&mut self) {
         let position = self.find_format_on_position(self.next_position);
         self.add_span(&(self.next_position, position));
@@ -281,6 +285,7 @@ impl<'a> ItemWriter<'a> {
                     self.writer.current_column()
                 }
             }
+            Indent::Absolute(n) => *n,
         };
         let mut needs_newline = false;
         let mut allow_multi_line = true;
@@ -472,10 +477,11 @@ pub enum Indent {
     CurrentColumn,
     Offset(usize),
     ParentOffset(usize),
+    Absolute(usize),
 }
 
 impl Indent {
-    pub fn inherit() -> Self {
+    pub const fn inherit() -> Self {
         Self::Offset(0)
     }
 }

--- a/src/format/writer.rs
+++ b/src/format/writer.rs
@@ -123,6 +123,14 @@ impl Writer {
             self.region.current_column = self.current_indent();
         }
 
+        let is_first_span = self.region.buf_start == self.buf.len();
+        if is_first_span {
+            for _ in self.region.current_column..self.current_indent() {
+                self.buf.push(' ');
+                self.region.current_column = self.current_indent();
+            }
+        }
+
         self.write(text, false)?;
         self.region.next_position = end;
         Ok(())

--- a/src/items.rs
+++ b/src/items.rs
@@ -30,6 +30,10 @@ pub struct ModuleOrConfig(Either<Module, Config>);
 pub struct Form(self::forms::Form);
 
 impl Form {
+    fn get(&self) -> &self::forms::Form {
+        &self.0
+    }
+
     pub(crate) fn is_func_spec(&self) -> bool {
         matches!(self.0, self::forms::Form::FunSpec(_))
     }

--- a/src/items/forms.rs
+++ b/src/items/forms.rs
@@ -239,10 +239,8 @@ impl DefineDirective {
     pub fn replacement(&self) -> &[LexicalToken] {
         self.replacement.tokens()
     }
-}
 
-impl Format for DefineDirective {
-    fn format(&self, fmt: &mut Formatter) {
+    pub fn format_with_indent(&self, fmt: &mut Formatter, replacement_indent: Option<usize>) {
         self.hyphen.format(fmt);
         self.define.format(fmt);
         self.open.format(fmt);
@@ -251,12 +249,22 @@ impl Format for DefineDirective {
             self.variables.format(fmt);
             self.comma.format(fmt);
             fmt.add_space();
-            fmt.subregion(Indent::inherit(), Newline::IfTooLongOrMultiLine, |fmt| {
+
+            let indent = replacement_indent
+                .map(Indent::Absolute)
+                .unwrap_or(Indent::inherit());
+            fmt.subregion(indent, Newline::IfTooLongOrMultiLine, |fmt| {
                 self.replacement.format(fmt)
             });
         });
         self.close.format(fmt);
         self.dot.format(fmt);
+    }
+}
+
+impl Format for DefineDirective {
+    fn format(&self, fmt: &mut Formatter) {
+        self.format_with_indent(fmt, None);
     }
 }
 

--- a/src/items/macros.rs
+++ b/src/items/macros.rs
@@ -305,6 +305,7 @@ mod tests {
             indoc::indoc! {"
             -define(FOO_OPEN,
                     foo().
+
             -define(FOO_CLOSE,
                     )).
 
@@ -509,6 +510,7 @@ mod tests {
                     ?FOO
                         1
                     end).
+
             -define(FOO, begin).
 
 
@@ -519,6 +521,7 @@ mod tests {
             %---10---|%---20---|
             -define(FOO,
                     ?BAR(1)).
+
             -define(BAR(X), X).
 
 

--- a/src/parse/token_stream.rs
+++ b/src/parse/token_stream.rs
@@ -8,7 +8,7 @@ use crate::items::tokens::{
 };
 use crate::parse::include::IncludeHandler;
 use crate::parse::{Error, IncludeOptions, Parse, Result, ResumeParse};
-use crate::span::{Position, Span as _};
+use crate::span::{Position, Span};
 use erl_tokenize::values::Symbol;
 use erl_tokenize::{PositionRange as _, Tokenizer};
 use std::collections::{BTreeMap, HashSet};
@@ -149,6 +149,13 @@ impl TokenStream {
 
     pub fn filepath(&self) -> Option<Arc<PathBuf>> {
         self.path.clone()
+    }
+
+    pub fn contains_comment(&self, span: &impl Span) -> bool {
+        self.comments
+            .range(span.start_position()..span.end_position())
+            .count()
+            > 0
     }
 
     pub fn comments(&self) -> &BTreeMap<Position, CommentToken> {

--- a/tests/testdata/aligned_macro.erl
+++ b/tests/testdata/aligned_macro.erl
@@ -1,0 +1,25 @@
+-module(aligned_macro).
+
+-define(a,   1).
+-define(bb,  2).
+-define(ccc, 3).
+
+-define(dddd,  11).
+-define(eeeee, 123).
+
+-define(a, 1).
+-define(bb(B), 2).
+-define(ccc,  3).
+-define(dddd, 4).
+
+-define(a, 1).
+-define(bb,  % foo
+        2).
+-define(ccc,  3).
+-define(dddd, 4).
+
+-define(a,  1).
+-define(bb, 2).
+%% bar
+-define(ccc,  3).
+-define(dddd, 4).

--- a/tests/testdata/weird_macro.erl
+++ b/tests/testdata/weird_macro.erl
@@ -3,7 +3,7 @@
 -define(FOO, /).
 -define(BAR, :format().
 -define(baz(A), A).
--define(qux, -> [1, 2, 3], [).
+-define(qux,  -> [1, 2, 3], [).
 -define(quux, )], [2,).
 -define(a(A, B), A).
 


### PR DESCRIPTION
Before
```erlang
-module(aligned_macro).

-define(a, 1).
-define(bb, 2).
-define(ccc, 3).

-define(dddd, 11).
-define(eeeee, 123).

-define(a, 1).
-define(bb(B), 2).
-define(ccc, 3).
-define(dddd, 4).

-define(a, 1).
-define(bb,  % foo
        2).
-define(ccc, 3).
-define(dddd, 4).

-define(a, 1).
-define(bb, 2).
%% bar
-define(ccc, 3).
-define(dddd, 4).
```

After
```erlang
-module(aligned_macro).

-define(a,   1).
-define(bb,  2).
-define(ccc, 3).

-define(dddd,  11).
-define(eeeee, 123).

-define(a, 1).
-define(bb(B), 2).
-define(ccc,  3).
-define(dddd, 4).

-define(a, 1).
-define(bb,  % foo
        2).
-define(ccc,  3).
-define(dddd, 4).

-define(a,  1).
-define(bb, 2).
%% bar
-define(ccc,  3).
-define(dddd, 4).
```