### PR TITLE
Explicitly specify the formatting rules for `-export` and `-export_type`

### DIFF
--- a/src/items/atoms.rs
+++ b/src/items/atoms.rs
@@ -50,3 +50,11 @@ impl_parse!(CallbackAtom, "callback");
 #[derive(Debug, Clone, Span, Format, Element)]
 pub struct RecordAtom(AtomToken);
 impl_parse!(RecordAtom, "record");
+
+#[derive(Debug, Clone, Span, Format, Element)]
+pub struct ExportAtom(AtomToken);
+impl_parse!(ExportAtom, "export");
+
+#[derive(Debug, Clone, Span, Format, Element)]
+pub struct ExportTypeAtom(AtomToken);
+impl_parse!(ExportTypeAtom, "export_type");

--- a/tests/testdata/export.erl
+++ b/tests/testdata/export.erl
@@ -1,0 +1,16 @@
+%%---10--|----20---|----30---|----40---|----50---|
+-module(export).
+
+-export([foo/0,
+         bar/0,
+         baz/0]).
+
+-export_type([foo/0, foo/1, foo/2]).
+
+-export([foo/0,
+
+         foo/1,
+         bar/0, bar/1,
+         baz/0, baz/1, baz/2, baz/3, baz/4, baz/5,
+         baz/6,
+         qux/0]).

--- a/tests/testdata/long_export.erl
+++ b/tests/testdata/long_export.erl
@@ -7,7 +7,8 @@
          ddd/0,
          eee/0,
          fff/0]).
--export([ggg/0, hhh/0]).
+-export([ggg/0,
+         hhh/0]).
 
 
 aaa() ->

--- a/tests/testdata/long_params.erl
+++ b/tests/testdata/long_params.erl
@@ -1,7 +1,9 @@
 %%---10--|----20---|----30---|----40---|----50---|
 -module(long_params).
 
--export([foo/7, bar/6, baz/5]).
+-export([foo/7,
+         bar/6,
+         baz/5]).
 
 
 foo(AAAAA,


### PR DESCRIPTION
## Before

```erlang
-export([foo/0, foo/1, bar/0, baz/0, baz/1, baz/2]).
```

## After

```erlang
-export([foo/0, foo/1,
         bar/0,
         baz/0, baz/1, baz/2]).
```