### PR TITLE
Don't insert a newline after binary op as much as possible

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -61,4 +61,8 @@ impl Expr {
     pub(crate) fn get(&self) -> &self::expressions::FullExpr {
         &self.0
     }
+
+    pub(crate) fn is_block(&self) -> bool {
+        self.0.is_block()
+    }
 }

--- a/src/items/components.rs
+++ b/src/items/components.rs
@@ -321,12 +321,12 @@ impl<T> Element for MapItem<T> {
 #[derive(Debug, Clone, Span, Parse, Format)]
 struct MapDelimiter(Either<DoubleRightArrowSymbol, MapMatchSymbol>);
 
-impl BinaryOpStyle for MapDelimiter {
+impl<RHS> BinaryOpStyle<RHS> for MapDelimiter {
     fn indent(&self) -> Indent {
         Indent::Offset(4)
     }
 
-    fn newline(&self) -> Newline {
+    fn newline(&self, _rhs: &RHS) -> Newline {
         Newline::IfTooLongOrMultiLine
     }
 }
@@ -362,10 +362,10 @@ impl<O, T> UnaryOpLike<O, T> {
     }
 }
 
-pub trait BinaryOpStyle {
+pub trait BinaryOpStyle<RHS> {
     fn indent(&self) -> Indent;
 
-    fn newline(&self) -> Newline;
+    fn newline(&self, rhs: &RHS) -> Newline;
 }
 
 #[derive(Debug, Clone, Span, Parse)]
@@ -391,7 +391,7 @@ impl<L: Parse, O: Parse, R: Parse> ResumeParse<L> for BinaryOpLike<L, O, R> {
     }
 }
 
-impl<L: Format, O: Format + BinaryOpStyle, R: Format> Format for BinaryOpLike<L, O, R> {
+impl<L: Format, O: Format + BinaryOpStyle<R>, R: Format> Format for BinaryOpLike<L, O, R> {
     fn format(&self, fmt: &mut Formatter) {
         self.left.format(fmt);
 
@@ -400,7 +400,7 @@ impl<L: Format, O: Format + BinaryOpStyle, R: Format> Format for BinaryOpLike<L,
         fmt.add_space();
 
         let indent = self.op.indent();
-        let newline = self.op.newline();
+        let newline = self.op.newline(&self.right);
         fmt.subregion(indent, newline, |fmt| self.right.format(fmt));
     }
 }

--- a/src/items/expressions.rs
+++ b/src/items/expressions.rs
@@ -154,6 +154,10 @@ impl FullExpr {
     pub fn is_integer_token(&self) -> bool {
         matches!(self, Self::Base(BaseExpr::Literal(LiteralExpr::Integer(_))))
     }
+
+    pub fn is_block(&self) -> bool {
+        matches!(self, Self::Base(BaseExpr::Block(_)))
+    }
 }
 
 impl Element for FullExpr {

--- a/src/items/expressions/calls.rs
+++ b/src/items/expressions/calls.rs
@@ -127,9 +127,9 @@ mod tests {
             6"},
             indoc::indoc! {"
             %---10---|%---20---|
-            {A, B, C} =
-                {Foo, bar,
-                 baz} =
+            {A, B, C} = {Foo,
+                         bar,
+                         baz} =
                     qux() /
                     quux() div 2"},
             indoc::indoc! {"

--- a/src/items/expressions/records.rs
+++ b/src/items/expressions/records.rs
@@ -103,12 +103,12 @@ struct RecordField(BinaryOpLike<Either<AtomToken, UnderscoreVariable>, RecordFie
 #[derive(Debug, Clone, Span, Parse, Format)]
 struct RecordFieldDelimiter(MatchSymbol);
 
-impl BinaryOpStyle for RecordFieldDelimiter {
+impl<RHS> BinaryOpStyle<RHS> for RecordFieldDelimiter {
     fn indent(&self) -> Indent {
         Indent::Offset(4)
     }
 
-    fn newline(&self) -> Newline {
+    fn newline(&self, _rhs: &RHS) -> Newline {
         Newline::IfTooLongOrMultiLine
     }
 }

--- a/src/items/types.rs
+++ b/src/items/types.rs
@@ -121,12 +121,12 @@ type FunctionParamsAndReturn = BinaryOpLike<FunctionParams, RightArrowDelimiter,
 #[derive(Debug, Clone, Span, Parse, Format)]
 struct RightArrowDelimiter(RightArrowSymbol);
 
-impl BinaryOpStyle for RightArrowDelimiter {
+impl<RHS> BinaryOpStyle<RHS> for RightArrowDelimiter {
     fn indent(&self) -> Indent {
         Indent::Offset(8)
     }
 
-    fn newline(&self) -> Newline {
+    fn newline(&self, _rhs: &RHS) -> Newline {
         Newline::IfTooLongOrMultiLine
     }
 }
@@ -201,12 +201,12 @@ struct RecordItem(BinaryOpLike<AtomToken, DoubleColonDelimiter, Type>);
 #[derive(Debug, Clone, Span, Parse, Format)]
 struct DoubleColonDelimiter(DoubleColonSymbol);
 
-impl BinaryOpStyle for DoubleColonDelimiter {
+impl<RHS> BinaryOpStyle<RHS> for DoubleColonDelimiter {
     fn indent(&self) -> Indent {
         Indent::Offset(4)
     }
 
-    fn newline(&self) -> Newline {
+    fn newline(&self, _rhs: &RHS) -> Newline {
         Newline::IfTooLongOrMultiLine
     }
 }

--- a/src/items/types/components.rs
+++ b/src/items/types/components.rs
@@ -28,12 +28,12 @@ pub enum BinaryOp {
     Range(DoubleDotSymbol),
 }
 
-impl BinaryOpStyle for BinaryOp {
+impl<RHS> BinaryOpStyle<RHS> for BinaryOp {
     fn indent(&self) -> Indent {
         Indent::inherit()
     }
 
-    fn newline(&self) -> Newline {
+    fn newline(&self, _rhs: &RHS) -> Newline {
         Newline::IfTooLong
     }
 }


### PR DESCRIPTION
## Before

```erlang
ok = 
    foo(bar, baz)
```

## After

```erlang
ok = foo(bar,
         baz)
```

Note that, as an exception, if the RHS part is a block (such as `case` or `received`, etc), an newline will always be inserted.