### PR TITLE
Don't insert a newline before a block if it's a macro expanded one

### DIFF
--- a/src/items/components.rs
+++ b/src/items/components.rs
@@ -326,7 +326,7 @@ impl<RHS> BinaryOpStyle<RHS> for MapDelimiter {
         Indent::Offset(4)
     }
 
-    fn newline(&self, _rhs: &RHS) -> Newline {
+    fn newline(&self, _rhs: &RHS, _fmt: &Formatter) -> Newline {
         Newline::IfTooLongOrMultiLine
     }
 }
@@ -365,7 +365,7 @@ impl<O, T> UnaryOpLike<O, T> {
 pub trait BinaryOpStyle<RHS> {
     fn indent(&self) -> Indent;
 
-    fn newline(&self, rhs: &RHS) -> Newline;
+    fn newline(&self, rhs: &RHS, fmt: &Formatter) -> Newline;
 }
 
 #[derive(Debug, Clone, Span, Parse)]
@@ -400,7 +400,7 @@ impl<L: Format, O: Format + BinaryOpStyle<R>, R: Format> Format for BinaryOpLike
         fmt.add_space();
 
         let indent = self.op.indent();
-        let newline = self.op.newline(&self.right);
+        let newline = self.op.newline(&self.right, fmt);
         fmt.subregion(indent, newline, |fmt| self.right.format(fmt));
     }
 }

--- a/src/items/expressions/calls.rs
+++ b/src/items/expressions/calls.rs
@@ -141,6 +141,13 @@ mod tests {
              d = bazzzzzzzzzzzzzz,
              qux =
                  quuxxxxxxxxxxx]"},
+            indoc::indoc! {"
+            %---10---|%---20---|
+            foo =
+                case bar of
+                    baz ->
+                        ok
+                end"},
         ];
         for text in texts {
             crate::assert_format!(text, Expr);

--- a/src/items/expressions/components.rs
+++ b/src/items/expressions/components.rs
@@ -72,7 +72,7 @@ impl<RHS> BinaryOpStyle<RHS> for GeneratorDelimiter {
         Indent::Offset(4)
     }
 
-    fn newline(&self, _rhs: &RHS) -> Newline {
+    fn newline(&self, _rhs: &RHS, _fmt: &Formatter) -> Newline {
         Newline::Never
     }
 }
@@ -104,7 +104,7 @@ impl<RHS> BinaryOpStyle<RHS> for ComprehensionDelimiter {
         Indent::ParentOffset(4)
     }
 
-    fn newline(&self, _rhs: &RHS) -> Newline {
+    fn newline(&self, _rhs: &RHS, _fmt: &Formatter) -> Newline {
         Newline::IfTooLongOrMultiLine
     }
 }
@@ -202,8 +202,14 @@ impl BinaryOpStyle<Expr> for BinaryOp {
         }
     }
 
-    fn newline(&self, rhs: &Expr) -> Newline {
-        if rhs.is_block() {
+    fn newline(&self, rhs: &Expr, fmt: &Formatter) -> Newline {
+        let is_macro_expanded = || {
+            fmt.token_stream()
+                .macros()
+                .contains_key(&rhs.start_position())
+        };
+
+        if rhs.is_block() && !is_macro_expanded() {
             Newline::Always
         } else if matches!(self, Self::Send(_)) {
             Newline::Never

--- a/src/items/expressions/records.rs
+++ b/src/items/expressions/records.rs
@@ -1,4 +1,4 @@
-use crate::format::{Format, Indent, Newline};
+use crate::format::{Format, Formatter, Indent, Newline};
 use crate::items::components::{BinaryOpLike, BinaryOpStyle, Element, TupleLike};
 use crate::items::expressions::Either;
 use crate::items::symbols::{DotSymbol, MatchSymbol, SharpSymbol};
@@ -108,7 +108,7 @@ impl<RHS> BinaryOpStyle<RHS> for RecordFieldDelimiter {
         Indent::Offset(4)
     }
 
-    fn newline(&self, _rhs: &RHS) -> Newline {
+    fn newline(&self, _rhs: &RHS, _fmt: &Formatter) -> Newline {
         Newline::IfTooLongOrMultiLine
     }
 }

--- a/src/items/macros.rs
+++ b/src/items/macros.rs
@@ -559,4 +559,22 @@ mod tests {
             crate::assert_format!(text, Module);
         }
     }
+
+    #[test]
+    fn macro_and_binary_op() {
+        let texts = [indoc::indoc! {"
+            %---10---|%---20---|
+            -define(FOO,
+                    case bar of
+                        baz ->
+                            ok
+                    end).
+
+
+            foo() ->
+                ok = ?FOO."}];
+        for text in texts {
+            crate::assert_format!(text, Module);
+        }
+    }
 }

--- a/src/items/macros.rs
+++ b/src/items/macros.rs
@@ -572,7 +572,8 @@ mod tests {
 
 
             foo() ->
-                ok = ?FOO."}];
+                ok = ?FOO.
+            "}];
         for text in texts {
             crate::assert_format!(text, Module);
         }

--- a/src/items/types.rs
+++ b/src/items/types.rs
@@ -126,7 +126,7 @@ impl<RHS> BinaryOpStyle<RHS> for RightArrowDelimiter {
         Indent::Offset(8)
     }
 
-    fn newline(&self, _rhs: &RHS) -> Newline {
+    fn newline(&self, _rhs: &RHS, _fmt: &Formatter) -> Newline {
         Newline::IfTooLongOrMultiLine
     }
 }
@@ -206,7 +206,7 @@ impl<RHS> BinaryOpStyle<RHS> for DoubleColonDelimiter {
         Indent::Offset(4)
     }
 
-    fn newline(&self, _rhs: &RHS) -> Newline {
+    fn newline(&self, _rhs: &RHS, _fmt: &Formatter) -> Newline {
         Newline::IfTooLongOrMultiLine
     }
 }

--- a/src/items/types/components.rs
+++ b/src/items/types/components.rs
@@ -1,4 +1,4 @@
-use crate::format::{Format, Indent, Newline};
+use crate::format::{Format, Formatter, Indent, Newline};
 use crate::items::components::{BinaryOpStyle, Either, Element};
 use crate::items::keywords::{
     BandKeyword, BnotKeyword, BorKeyword, BslKeyword, BsrKeyword, BxorKeyword, DivKeyword,
@@ -33,7 +33,7 @@ impl<RHS> BinaryOpStyle<RHS> for BinaryOp {
         Indent::inherit()
     }
 
-    fn newline(&self, _rhs: &RHS) -> Newline {
+    fn newline(&self, _rhs: &RHS, _fmt: &Formatter) -> Newline {
         Newline::IfTooLong
     }
 }


### PR DESCRIPTION
Fix a bug introduced in https://github.com/sile/efmt/pull/22.

## Before (bug)

```erlang
-include_lib("kernel/include/logger.hrl").


foo() ->
    ok =
        ?LOG_DEBUG("hi").  % ?LOG_DEBUG is expanded to a block
```

### After

```erlang
-include_lib("kernel/include/logger.hrl").


foo() ->
    ok = ?LOG_DEBUG("hi").
```