### PR TITLE
Don't insert a newline after a map delimiter as much as possible

### DIFF
--- a/src/items/components.rs
+++ b/src/items/components.rs
@@ -349,7 +349,7 @@ impl<RHS> BinaryOpStyle<RHS> for MapDelimiter {
     }
 
     fn newline(&self, _rhs: &RHS, _fmt: &Formatter) -> Newline {
-        Newline::IfTooLongOrMultiLine
+        Newline::IfTooLong
     }
 }
 

--- a/src/items/types.rs
+++ b/src/items/types.rs
@@ -297,10 +297,9 @@ mod tests {
                   integer()}"},
             indoc::indoc! {"
             %---10---|%---20---|
-            #{atom() :=
-                  {Aaa,
-                   bbb,
-                   ccc}}"},
+            #{atom() := {Aaa,
+                         bbb,
+                         ccc}}"},
             indoc::indoc! {"
             %---10---|%---20---|
             #{a => b,


### PR DESCRIPTION
### Before

```erlang
#{foo :=
      {bar, baz}}
```

### After

```erlang
#{foo := {bar,
          baz}}
```