### PR TITLE
Support EEP-49 (`maybe` syntax)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "erl_tokenize"
-version = "0.4.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687cfd7c827592c206846ad8c1fa4e48cee3278daaaea97c4ac81006a6e95fec"
+checksum = "4ac5dced32fb9c866a9a62e9c0c621f9536024fd42d0575468838b069aabb6f2"
 dependencies = [
  "num",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 anyhow = "1"
 console = "0.15"
-erl_tokenize = "0.4"
+erl_tokenize = "0.5"
 efmt_derive = { path = "efmt_derive", version = "0.1.0" }
 env_logger = "0.9"
 log = "0.4"

--- a/src/items/expressions/components.rs
+++ b/src/items/expressions/components.rs
@@ -127,6 +127,7 @@ pub enum BinaryOp {
     PlusPlus(symbols::PlusPlusSymbol),
     MinusMinus(symbols::MinusMinusSymbol),
     Match(symbols::MatchSymbol),
+    MaybeMatch(symbols::MaybeMatchSymbol),
     Eq(symbols::EqSymbol),
     ExactEq(symbols::ExactEqSymbol),
     NotEq(symbols::NotEqSymbol),
@@ -161,6 +162,7 @@ impl Parse for BinaryOp {
                 Symbol::PlusPlus => ts.parse().map(Self::PlusPlus),
                 Symbol::MinusMinus => ts.parse().map(Self::MinusMinus),
                 Symbol::Match => ts.parse().map(Self::Match),
+                Symbol::MaybeMatch => ts.parse().map(Self::MaybeMatch),
                 Symbol::Eq => ts.parse().map(Self::Eq),
                 Symbol::ExactEq => ts.parse().map(Self::ExactEq),
                 Symbol::NotEq => ts.parse().map(Self::NotEq),
@@ -195,7 +197,7 @@ impl Parse for BinaryOp {
 
 impl BinaryOpStyle<Expr> for BinaryOp {
     fn indent(&self) -> Indent {
-        if matches!(self, Self::Match(_)) {
+        if matches!(self, Self::Match(_) | Self::MaybeMatch(_)) {
             Indent::Offset(4)
         } else {
             Indent::inherit()

--- a/src/items/forms.rs
+++ b/src/items/forms.rs
@@ -9,7 +9,7 @@ use crate::items::components::{
     Parenthesized, WithArrow, WithGuard,
 };
 use crate::items::expressions::components::FunctionClause;
-use crate::items::keywords::IfKeyword;
+use crate::items::keywords::{ElseKeyword, IfKeyword};
 use crate::items::macros::{MacroName, MacroReplacement};
 use crate::items::symbols::{
     CloseBraceSymbol, CloseParenSymbol, CloseSquareSymbol, ColonSymbol, CommaSymbol, DotSymbol,
@@ -256,7 +256,7 @@ struct ExportItem {
 #[derive(Debug, Clone, Span, Parse, Format)]
 pub struct Attr(AttrLike<AttrName, AttrValue, Null>);
 
-type AttrName = Either<AtomToken, IfKeyword>;
+type AttrName = Either<AtomToken, Either<IfKeyword, ElseKeyword>>;
 type AttrValue = NonEmptyItems<Expr>;
 
 #[derive(Debug, Clone, Span, Parse)]

--- a/src/items/keywords.rs
+++ b/src/items/keywords.rs
@@ -126,3 +126,11 @@ impl_traits!(WhenKeyword, When);
 #[derive(Debug, Clone, Span, Format)]
 pub struct XorKeyword(KeywordToken);
 impl_traits!(XorKeyword, Xor);
+
+#[derive(Debug, Clone, Span, Format)]
+pub struct MaybeKeyword(KeywordToken);
+impl_traits!(MaybeKeyword, Maybe);
+
+#[derive(Debug, Clone, Span, Format)]
+pub struct ElseKeyword(KeywordToken);
+impl_traits!(ElseKeyword, Else);

--- a/src/items/symbols.rs
+++ b/src/items/symbols.rs
@@ -189,3 +189,7 @@ impl_traits!(LessSymbol, Less);
 #[derive(Debug, Clone, Span, Format)]
 pub struct LessEqSymbol(SymbolToken);
 impl_traits!(LessEqSymbol, LessEq);
+
+#[derive(Debug, Clone, Span, Format)]
+pub struct MaybeMatchSymbol(SymbolToken);
+impl_traits!(MaybeMatchSymbol, MaybeMatch);

--- a/tests/testdata/maybe_expr.erl
+++ b/tests/testdata/maybe_expr.erl
@@ -1,0 +1,47 @@
+%%---10--|----20---|----30---|----40---|----50---|
+%%
+%% The functions below is quoted from https://github.com/erlang/eep/blob/master/eeps/eep-0049.md
+-module(maybe_expr).
+
+
+commit_write(OpaqueData) ->
+    maybe
+        ok ?=
+            disk_log:sync(OpaqueData#backup.file_desc),
+        ok ?=
+            disk_log:close(OpaqueData#backup.file_desc),
+        ok ?=
+            file:rename(OpaqueData#backup.tmp_file,
+                        OpaqueData#backup.file),
+        {ok, OpaqueData#backup.file}
+    end.
+
+
+commit_write(OpaqueData) ->
+    maybe
+        ok ?=
+            disk_log:sync(OpaqueData#backup.file_desc),
+        ok ?=
+            disk_log:close(OpaqueData#backup.file_desc),
+        ok ?=
+            file:rename(OpaqueData#backup.tmp_file,
+                        OpaqueData#backup.file),
+        {ok, OpaqueData#backup.file}
+    else
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+
+-spec fetch() -> {ok, iodata()} | {error, _}.
+fetch() ->
+    maybe
+        {ok, B = <<_/binary>>} ?= f(),
+        true ?= validate(B),
+        {ok, sanitize(B)}
+    else
+        false ->
+            {error, invalid_data};
+        {error, R} ->
+            {error, R}
+    end.


### PR DESCRIPTION
This PR adds the support of the `maybe` syntax introduced in [EEP-49](https://github.com/erlang/eep/blob/master/eeps/eep-0049.md).