### PR TITLE
Collect include dirs from rebar.config

### DIFF
--- a/rebar3_efmt/src/rebar3_efmt_prv.erl
+++ b/rebar3_efmt/src/rebar3_efmt_prv.erl
@@ -35,7 +35,8 @@ do(State) ->
                  Flag ->
                      atom_to_arg_key(Flag)
              end || Entry <- rebar_state:get(State, efmt, [])] ++ Args0,
-    ok = rebar3_efmt_command:execute(Args1),
+    Args2 = ["-I=" ++ Dir || {i, Dir} <- rebar_state:get(State, erl_opts, [])] ++ Args1,
+    ok = rebar3_efmt_command:execute(Args2),
     {ok, State}.
 
 -spec format_error(any()) ->  iolist().


### PR DESCRIPTION
This PR updates `rebar3_efmt` plugin to collect include dirs from `rebar.config` file If there is a compiler option specifying include dirs such as  `{erl_opts, [{i, "..."}]}`.