### PR TITLE
Don't insert newlines after '=' and '::' in records as much as possible

### DIFF
--- a/src/items/expressions/records.rs
+++ b/src/items/expressions/records.rs
@@ -104,7 +104,7 @@ impl<RHS> BinaryOpStyle<RHS> for RecordFieldDelimiter {
     }
 
     fn newline(&self, _rhs: &RHS, _fmt: &Formatter) -> Newline {
-        Newline::IfTooLongOrMultiLine
+        Newline::IfTooLong
     }
 }
 
@@ -128,9 +128,8 @@ mod tests {
             %---10---|%---20---|
             #foo{
               bar = 2,
-              baz =
-                  {Bar, baz,
-                   qux}
+              baz = {Bar, baz,
+                     qux}
              }"},
         ];
         for text in texts {

--- a/src/items/types.rs
+++ b/src/items/types.rs
@@ -205,7 +205,7 @@ impl<RHS> BinaryOpStyle<RHS> for DoubleColonDelimiter {
     }
 
     fn newline(&self, _rhs: &RHS, _fmt: &Formatter) -> Newline {
-        Newline::IfTooLongOrMultiLine
+        Newline::IfTooLong
     }
 }
 


### PR DESCRIPTION
### Before

```erlang
#foo{
  bar =
      [111, 222]
 }
````

### After

```erlang
#foo{
  bar = [111,
         222]
 }
```