### PR TITLE
Improve binary op format

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -65,4 +65,8 @@ impl Expr {
     pub(crate) fn is_block(&self) -> bool {
         self.0.is_block()
     }
+
+    pub(crate) fn is_parenthesized(&self) -> bool {
+        self.0.is_parenthesized()
+    }
 }

--- a/src/items/expressions.rs
+++ b/src/items/expressions.rs
@@ -158,6 +158,10 @@ impl FullExpr {
     pub fn is_block(&self) -> bool {
         matches!(self, Self::Base(BaseExpr::Block(_)))
     }
+
+    pub fn is_parenthesized(&self) -> bool {
+        matches!(self, Self::Base(BaseExpr::Parenthesized(_)))
+    }
 }
 
 impl Element for FullExpr {

--- a/src/items/expressions/blocks.rs
+++ b/src/items/expressions/blocks.rs
@@ -264,8 +264,7 @@ mod tests {
                 {1, 2} ->
                     3;
                 A when is_integer(A),
-                       A >
-                       100 ->
+                       A > 100 ->
                     A / 10
             end"},
         ];

--- a/src/items/expressions/components.rs
+++ b/src/items/expressions/components.rs
@@ -226,6 +226,8 @@ impl BinaryOpStyle<Expr> for BinaryOp {
                 | Self::GreaterEq(_)
         ) {
             Newline::Never
+        } else if rhs.is_parenthesized() && !is_macro_expanded() {
+            Newline::IfTooLongOrMultiLine
         } else {
             Newline::IfTooLong
         }

--- a/src/items/expressions/components.rs
+++ b/src/items/expressions/components.rs
@@ -213,7 +213,18 @@ impl BinaryOpStyle<Expr> for BinaryOp {
 
         if rhs.is_block() && !is_macro_expanded() {
             Newline::Always
-        } else if matches!(self, Self::Send(_)) {
+        } else if matches!(
+            self,
+            Self::Send(_)
+                | Self::ExactEq(_)
+                | Self::Eq(_)
+                | Self::ExactNotEq(_)
+                | Self::NotEq(_)
+                | Self::Less(_)
+                | Self::LessEq(_)
+                | Self::Greater(_)
+                | Self::GreaterEq(_)
+        ) {
             Newline::Never
         } else {
             Newline::IfTooLong

--- a/tests/testdata/binary_op.erl
+++ b/tests/testdata/binary_op.erl
@@ -1,0 +1,9 @@
+%%---10--|----20---|----30---|----40---|----50---|
+-module(binary_op).
+
+
+foo(Bar, Baz)
+  when (Bar =:= ?AAA_AAA_AAA orelse
+        Bar =:= ?CCC_CCC_CCC_CCC_CCC) andalso
+       is_map_key(Bar, Baz) ->
+    ok.

--- a/tests/testdata/binary_op.erl
+++ b/tests/testdata/binary_op.erl
@@ -6,4 +6,6 @@ foo(Bar, Baz)
   when (Bar =:= ?AAA_AAA_AAA orelse
         Bar =:= ?CCC_CCC_CCC_CCC_CCC) andalso
        is_map_key(Bar, Baz) ->
+    Qux = (1 + 2 + 3 * 4 + 5 - 6 / 8) +
+        (1 + 2 + 3 * 4 + 5 - 6 / 8),
     ok.


### PR DESCRIPTION
### Before

```erlang
foo(Bar, Baz)
  when (Bar =:= ?AAA_AAA_AAA orelse Bar =:= 
        ?CCC_CCC_CCC_CCC_CCC) andalso
       is_map_key(Bar, Baz) ->
    Qux = (1 + 2 + 3 * 4 + 5 - 6 / 8) + (1 + 2 + 3 * 
                                         4 + 5 - 6 / 
                                         8),
    ok.
```

### After

```erlang
foo(Bar, Baz)
  when (Bar =:= ?AAA_AAA_AAA orelse
        Bar =:= ?CCC_CCC_CCC_CCC_CCC) andalso
       is_map_key(Bar, Baz) ->
    Qux = (1 + 2 + 3 * 4 + 5 - 6 / 8) +
        (1 + 2 + 3 * 4 + 5 - 6 / 8),
    ok.
```