### PR TITLE
Fix a map formatting bug

### DIFF
--- a/src/items/components.rs
+++ b/src/items/components.rs
@@ -392,7 +392,7 @@ impl<T: Format> Format for RecordFieldsLike<T> {
         fmt.subregion(Indent::Offset(1), Newline::Never, |fmt| {
             fmt.subregion(
                 Indent::Offset(1),
-                Newline::IfTooLongOrMultiLineParent,
+                Newline::IfTooLongOrMultiLineParentForce,
                 |fmt| {
                     self.format_fields(fmt);
                 },

--- a/src/items/expressions/maps.rs
+++ b/src/items/expressions/maps.rs
@@ -40,6 +40,12 @@ mod tests {
               foo => {666, 777,
                       888}
              }"},
+            indoc::indoc! {"
+            %---10---|%---20---|
+            #{
+              1 => 2,
+              333 => {444, 55}
+             }"},
         ];
         for text in texts {
             crate::assert_format!(text, Expr);


### PR DESCRIPTION
### Before

```erlang
#{aaa => bbb,
   111 => 222
 }
```

### After

```erlang
#{
  aaa => bbb,
  111 => 222,
 }
```