### PR TITLE
Update list/binary comprehension formats

### DIFF
--- a/src/format/formatter.rs
+++ b/src/format/formatter.rs
@@ -278,6 +278,14 @@ impl<'a> ItemWriter<'a> {
         let indent = match indent {
             Indent::Offset(n) => self.writer.current_indent() + n,
             Indent::ParentOffset(n) => self.writer.parent_indent() + n,
+            Indent::CurrentColumnOrOffset(n) => {
+                let column = if self.writer.current_column() == 0 {
+                    self.writer.current_indent()
+                } else {
+                    self.writer.current_column()
+                };
+                std::cmp::min(column, self.writer.current_indent() + n)
+            }
             Indent::CurrentColumn => {
                 if self.writer.current_column() == 0 {
                     self.writer.current_indent()
@@ -483,6 +491,7 @@ pub enum Indent {
     CurrentColumn,
     Offset(usize),
     ParentOffset(usize),
+    CurrentColumnOrOffset(usize),
     Absolute(usize),
 }
 

--- a/src/items/expressions/bitstrings.rs
+++ b/src/items/expressions/bitstrings.rs
@@ -122,29 +122,30 @@ mod tests {
         let texts = [
             indoc::indoc! {"
             %---10---|%---20---|
-            <<<<X>> ||
-                X <- [1, 2, 3]>>"},
+            << <<X>> ||
+                X <- [1, 2,
+                      3] >>"},
             indoc::indoc! {"
             %---10---|%---20---|
-            <<(foo(X,
-                   Y,
-                   Z,
-                   bar(),
-                   baz())) ||
+            << (foo(X,
+                    Y,
+                    Z,
+                    bar(),
+                    baz())) ||
                 X <- [1, 2, 3,
                       4, 5],
                 Y <= Z,
-                false>>"},
+                false >>"},
             indoc::indoc! {"
             %---10---|%---20---|
-            <<<<if
-                    X < 10 ->
-                        X + $0;
-                    true ->
-                        X - 10 +
-                        $A
-                end>> ||
-                <<X:4>> <= B>>"},
+            << <<if
+                     X < 10 ->
+                         X + $0;
+                     true ->
+                         X -
+                         10 + $A
+                 end>> ||
+                <<X:4>> <= B >>"},
         ];
         for text in texts {
             crate::assert_format!(text, Expr);

--- a/src/items/expressions/bitstrings.rs
+++ b/src/items/expressions/bitstrings.rs
@@ -145,7 +145,8 @@ mod tests {
                          X -
                          10 + $A
                  end>>
-               || <<X:4>> <= B >>"},
+               || <<X:4>>
+                      <= B >>"},
         ];
         for text in texts {
             crate::assert_format!(text, Expr);

--- a/src/items/expressions/bitstrings.rs
+++ b/src/items/expressions/bitstrings.rs
@@ -122,20 +122,20 @@ mod tests {
         let texts = [
             indoc::indoc! {"
             %---10---|%---20---|
-            << <<X>> ||
-                X <- [1, 2,
-                      3] >>"},
+            << <<X>>
+               || X <- [1, 2,
+                        3] >>"},
             indoc::indoc! {"
             %---10---|%---20---|
             << (foo(X,
                     Y,
                     Z,
                     bar(),
-                    baz())) ||
-                X <- [1, 2, 3,
-                      4, 5],
-                Y <= Z,
-                false >>"},
+                    baz()))
+               || X <- [1, 2, 3,
+                        4, 5],
+                  Y <= Z,
+                  false >>"},
             indoc::indoc! {"
             %---10---|%---20---|
             << <<if
@@ -144,8 +144,8 @@ mod tests {
                      true ->
                          X -
                          10 + $A
-                 end>> ||
-                <<X:4>> <= B >>"},
+                 end>>
+               || <<X:4>> <= B >>"},
         ];
         for text in texts {
             crate::assert_format!(text, Expr);

--- a/src/items/expressions/components.rs
+++ b/src/items/expressions/components.rs
@@ -80,7 +80,9 @@ impl<RHS> BinaryOpStyle<RHS> for GeneratorDelimiter {
 #[derive(Debug, Clone, Span, Parse)]
 pub(crate) struct ComprehensionExpr<Open, Close> {
     open: Open,
-    body: BinaryOpLike<Expr, ComprehensionDelimiter, NonEmptyItems<Qualifier>>,
+    value: Expr,
+    delimiter: DoubleVerticalBarSymbol,
+    qualifiers: NonEmptyItems<Qualifier>,
     close: Close,
 }
 
@@ -90,24 +92,19 @@ impl<Open: Format, Close: Format> Format for ComprehensionExpr<Open, Close> {
             self.open.format(fmt);
             fmt.add_space();
             fmt.subregion(Indent::CurrentColumn, Newline::Never, |fmt| {
-                self.body.format(fmt)
+                self.value.format(fmt);
+                fmt.add_space();
+                fmt.subregion(Indent::inherit(), Newline::IfTooLongOrMultiLine, |fmt| {
+                    self.delimiter.format(fmt);
+                    fmt.add_space();
+                    fmt.subregion(Indent::CurrentColumn, Newline::Never, |fmt| {
+                        self.qualifiers.format(fmt);
+                    });
+                });
             });
             fmt.add_space();
             self.close.format(fmt);
         });
-    }
-}
-
-#[derive(Debug, Clone, Span, Parse, Format)]
-struct ComprehensionDelimiter(DoubleVerticalBarSymbol);
-
-impl<RHS> BinaryOpStyle<RHS> for ComprehensionDelimiter {
-    fn indent(&self) -> Indent {
-        Indent::ParentOffset(4)
-    }
-
-    fn newline(&self, _rhs: &RHS, _fmt: &Formatter) -> Newline {
-        Newline::IfTooLongOrMultiLine
     }
 }
 

--- a/src/items/expressions/components.rs
+++ b/src/items/expressions/components.rs
@@ -1,6 +1,6 @@
 use crate::format::{Format, Formatter, Indent, Newline};
 use crate::items::components::{
-    BinaryOpLike, BinaryOpStyle, Either, NonEmptyItems, Params, WithArrow, WithGuard,
+    BinaryOpStyle, Either, NonEmptyItems, Params, WithArrow, WithGuard,
 };
 use crate::items::keywords;
 use crate::items::symbols::{
@@ -61,21 +61,31 @@ impl<const OFFSET: usize> Format for Body<OFFSET> {
 #[derive(Debug, Clone, Span, Parse, Format)]
 pub struct Qualifier(Either<Generator, Expr>);
 
-#[derive(Debug, Clone, Span, Parse, Format)]
-struct Generator(BinaryOpLike<Expr, GeneratorDelimiter, Expr>);
+#[derive(Debug, Clone, Span, Parse)]
+struct Generator {
+    pattern: Expr,
+    delimiter: GeneratorDelimiter,
+    sequence: Expr,
+}
+
+impl Format for Generator {
+    fn format(&self, fmt: &mut Formatter) {
+        self.pattern.format(fmt);
+        fmt.add_space();
+        fmt.subregion(
+            Indent::CurrentColumnOrOffset(4),
+            Newline::IfTooLong,
+            |fmt| {
+                self.delimiter.format(fmt);
+                fmt.add_space();
+                self.sequence.format(fmt);
+            },
+        );
+    }
+}
 
 #[derive(Debug, Clone, Span, Parse, Format)]
 struct GeneratorDelimiter(Either<LeftArrowSymbol, DoubleLeftArrowSymbol>);
-
-impl<RHS> BinaryOpStyle<RHS> for GeneratorDelimiter {
-    fn indent(&self) -> Indent {
-        Indent::Offset(4)
-    }
-
-    fn newline(&self, _rhs: &RHS, _fmt: &Formatter) -> Newline {
-        Newline::Never
-    }
-}
 
 #[derive(Debug, Clone, Span, Parse)]
 pub(crate) struct ComprehensionExpr<Open, Close> {

--- a/src/items/expressions/components.rs
+++ b/src/items/expressions/components.rs
@@ -88,9 +88,11 @@ impl<Open: Format, Close: Format> Format for ComprehensionExpr<Open, Close> {
     fn format(&self, fmt: &mut Formatter) {
         fmt.subregion(Indent::CurrentColumn, Newline::Never, |fmt| {
             self.open.format(fmt);
+            fmt.add_space();
             fmt.subregion(Indent::CurrentColumn, Newline::Never, |fmt| {
                 self.body.format(fmt)
             });
+            fmt.add_space();
             self.close.format(fmt);
         });
     }

--- a/src/items/expressions/lists.rs
+++ b/src/items/expressions/lists.rs
@@ -101,18 +101,18 @@ mod tests {
         let texts = [
             indoc::indoc! {"
             %---10---|%---20---|
-            [X || X <- [1, 2]]"},
+            [ X || X <- [1, 2] ]"},
             indoc::indoc! {"
             %---10---|%---20---|
-            [X ||
-                X <- [1, 2, 3]]"},
+            [ X ||
+                X <- [1, 2, 3] ]"},
             indoc::indoc! {"
             %---10---|%---20---|
-            [[X, Y] ||
+            [ [X, Y] ||
                 X <- [1, 2, 3,
                       4, 5],
                 Y <= Z,
-                false]"},
+                false ]"},
         ];
         for text in texts {
             crate::assert_format!(text, Expr);

--- a/src/items/expressions/lists.rs
+++ b/src/items/expressions/lists.rs
@@ -104,15 +104,16 @@ mod tests {
             [ X || X <- [1, 2] ]"},
             indoc::indoc! {"
             %---10---|%---20---|
-            [ X ||
-                X <- [1, 2, 3] ]"},
+            [ X
+              || X <- [1, 2,
+                       3] ]"},
             indoc::indoc! {"
             %---10---|%---20---|
-            [ [X, Y] ||
-                X <- [1, 2, 3,
-                      4, 5],
-                Y <= Z,
-                false ]"},
+            [ [X, Y]
+              || X <- [1, 2, 3,
+                       4, 5],
+                 Y <= Z,
+                 false ]"},
         ];
         for text in texts {
             crate::assert_format!(text, Expr);


### PR DESCRIPTION
### Before

```erlang
%% |------ print width --------|
[foo ||
     {Bar0, Bar1} <- [baz, qux, quux]]
```

### After

```erlang
%% |------ print width --------|
[ foo
  || {Bar0, Bar1}
         <- [baz, qux, quux] ]
```