### PR TITLE
Don't pack `orelse` and `andalso` if multiline mode

### DIFF
--- a/src/items/expressions/components.rs
+++ b/src/items/expressions/components.rs
@@ -235,6 +235,8 @@ impl BinaryOpStyle<Expr> for BinaryOp {
                 | Self::GreaterEq(_)
         ) {
             Newline::Never
+        } else if matches!(self, Self::Andalso(_) | Self::Orelse(_)) {
+            Newline::IfTooLongOrMultiLineParent
         } else if rhs.is_parenthesized() && !is_macro_expanded() {
             Newline::IfTooLongOrMultiLine
         } else {

--- a/tests/testdata/guard.erl
+++ b/tests/testdata/guard.erl
@@ -1,0 +1,43 @@
+%%---10--|----20---|----30---|----40---|----50---|
+-module(guard).
+
+
+foo()
+  when aaa;
+       bbb,
+       ccc;
+       ddd;
+       eee,
+       fff;
+       ggg;
+       hhh,
+       iii ->
+    ok.
+
+
+bar()
+  when aaa andalso
+       bbb orelse
+       ccc andalso
+       ddd orelse
+       eee orelse
+       (fff orelse
+        ggg andalso
+        hhh orelse
+        iii andalso
+        jjj) orelse
+       kkk orelse
+       lll ->
+    ok.
+
+
+baz()
+  when aaa andalso bbb orelse ccc;
+       ddd orelse eee,
+       (fff orelse
+        ggg andalso
+        hhh orelse
+        iii andalso
+        jjj) orelse
+       kkk ->
+    ok.


### PR DESCRIPTION
## Before

```erlang
foo orelse bar orelse
baz andalso qux.
```

### After

```erlang
foo orelse
bar orelse
baz andalso
qux.
```