### PR TITLE
Fix a bug that  anonymous function bodies use 7 spaces in some cases

### DIFF
--- a/src/items/expressions/components.rs
+++ b/src/items/expressions/components.rs
@@ -24,7 +24,7 @@ impl<Name: Format, const OFFSET: usize> FunctionClause<Name, OFFSET> {
         self.name.format(fmt);
         self.params.format(fmt);
         fmt.subregion(
-            Indent::Offset(4),
+            Indent::Offset(OFFSET),
             Newline::IfTooLongOrMultiLineParent,
             |fmt| self.body.exprs.format(fmt),
         );

--- a/tests/testdata/function.erl
+++ b/tests/testdata/function.erl
@@ -10,3 +10,12 @@ foo() ->
                        hello,
                        ok
                end.
+
+
+bar() ->
+    fun() ->
+            fun() ->
+                    hello,
+                    world
+            end
+    end.


### PR DESCRIPTION
### Before

```erlang
bar() ->
    fun() ->
           fun() ->  % 7 spaces
                   hello,
                   world
           end
    end.
```

### After

```erlang
bar() ->
    fun() ->
            fun() ->  % 8 spaces
                    hello,
                    world
            end
    end.
```