### PR TITLE
Remove spaces from integer range types

### DIFF
--- a/src/items/components.rs
+++ b/src/items/components.rs
@@ -441,6 +441,10 @@ pub trait BinaryOpStyle<RHS> {
     fn indent(&self) -> Indent;
 
     fn newline(&self, rhs: &RHS, fmt: &Formatter) -> Newline;
+
+    fn needs_spaces(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Debug, Clone, Span, Parse)]
@@ -470,9 +474,13 @@ impl<L: Format, O: Format + BinaryOpStyle<R>, R: Format> Format for BinaryOpLike
     fn format(&self, fmt: &mut Formatter) {
         self.left.format(fmt);
 
-        fmt.add_space();
-        self.op.format(fmt);
-        fmt.add_space();
+        if self.op.needs_spaces() {
+            fmt.add_space();
+            self.op.format(fmt);
+            fmt.add_space();
+        } else {
+            self.op.format(fmt);
+        }
 
         let indent = self.op.indent();
         let newline = self.op.newline(&self.right, fmt);

--- a/src/items/types.rs
+++ b/src/items/types.rs
@@ -383,7 +383,7 @@ mod tests {
             %---10---|%---20---|
             foo |
             (3 + 10) |
-            -1 .. +20"},
+            -1..+20"},
         ];
         for text in texts {
             crate::assert_format!(text, Type);

--- a/src/items/types/components.rs
+++ b/src/items/types/components.rs
@@ -36,6 +36,14 @@ impl<RHS> BinaryOpStyle<RHS> for BinaryOp {
     fn newline(&self, _rhs: &RHS, _fmt: &Formatter) -> Newline {
         Newline::IfTooLong
     }
+
+    fn needs_spaces(&self) -> bool {
+        if matches!(self, Self::Range(_)) {
+            false
+        } else {
+            true
+        }
+    }
 }
 
 /// `+` | `-` | `bnot`

--- a/src/items/types/components.rs
+++ b/src/items/types/components.rs
@@ -38,11 +38,7 @@ impl<RHS> BinaryOpStyle<RHS> for BinaryOp {
     }
 
     fn needs_spaces(&self) -> bool {
-        if matches!(self, Self::Range(_)) {
-            false
-        } else {
-            true
-        }
+        !matches!(self, Self::Range(_))
     }
 }
 


### PR DESCRIPTION
### Before

```erlang
1 .. 10
```

### After

```erlang
1..10
```