### PR TITLE
Ensure two blank lines are inserted before / after function decls

### DIFF
--- a/src/format/formatter.rs
+++ b/src/format/formatter.rs
@@ -139,6 +139,24 @@ impl Formatter {
         self.item.add_space();
     }
 
+    pub fn flush_non_preceding_comments(&mut self, next: &impl Span) {
+        for (i, comment_start) in self
+            .ts
+            .comments()
+            .range(self.next_position..next.start_position())
+            .map(|(k, _)| *k)
+            .rev()
+            .enumerate()
+        {
+            if comment_start.line() == next.start_position().line() - i - 1 {
+                continue;
+            }
+
+            self.add_macros_and_comments(comment_start);
+            break;
+        }
+    }
+
     pub fn add_newline(&mut self) {
         self.add_newlines(NonZeroUsize::new(1).expect("unreachable"));
     }

--- a/src/items/module.rs
+++ b/src/items/module.rs
@@ -5,6 +5,8 @@ use crate::parse::{self, Parse, TokenStream};
 use crate::span::{Position, Span};
 use std::num::NonZeroUsize;
 
+const THREE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(3) };
+
 /// [Form]*
 #[derive(Debug, Clone, Span)]
 pub struct Module {
@@ -31,8 +33,14 @@ impl Format for Module {
             is_last_spec: false,
             pending_constants: Vec::new(),
         };
+        let mut is_last_fun_decl = false;
 
         for form in &self.forms {
+            if is_last_fun_decl {
+                fmt.add_newlines(THREE);
+                is_last_fun_decl = false;
+            }
+
             if state.pend_if_need(fmt, form) {
                 continue;
             }
@@ -45,6 +53,7 @@ impl Format for Module {
 
             form.format(fmt);
             fmt.add_newline();
+            is_last_fun_decl = form.is_func_decl();
         }
 
         state.flush_pendings(fmt);
@@ -108,14 +117,14 @@ impl<'a> FormatState<'a> {
     }
 
     fn insert_two_empty_newlines_if_need(&mut self, fmt: &mut Formatter, form: &'a Form) {
-        const THREE: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(3) };
-
         if form.is_func_decl() && !self.is_last_spec {
+            fmt.flush_non_preceding_comments(form);
             fmt.add_newlines(THREE);
         }
 
         self.is_last_spec = form.is_func_spec();
         if form.is_func_spec() {
+            fmt.flush_non_preceding_comments(form);
             fmt.add_newlines(THREE);
         }
     }

--- a/tests/testdata/ftp_server.erl
+++ b/tests/testdata/ftp_server.erl
@@ -1,5 +1,6 @@
 % From: http://www1.erlang.org/examples/examples-2.0.html
 
+
 start() ->
     case (catch register(ftp_server,
                          spawn(?MODULE,

--- a/tests/testdata/function.erl
+++ b/tests/testdata/function.erl
@@ -12,10 +12,31 @@ foo() ->
                end.
 
 
+-spec bar() -> term().
 bar() ->
     fun() ->
             fun() ->
                     hello,
                     world
             end
-    end.
+    end.  % bar
+
+
+baz() ->
+    ok.
+
+
+-type qux() :: any().
+%% This is qux.
+
+
+-spec qux() -> ok.
+qux() ->
+    ok.
+
+
+%%----
+
+
+quux() ->
+    ok.


### PR DESCRIPTION
### Before

```erlang
-type foo() :: atom().


% This is foo() type

bar() ->
    ok.   % ok
baz() ->
    ok.
```

### After

```erlang
-type foo() :: atom().
% This is foo() type


bar() ->
    ok.  % ok


baz() ->
    ok.
```