### PR TITLE
Use four spaces to indent `when` in `-spec`

### DIFF
--- a/src/items/components.rs
+++ b/src/items/components.rs
@@ -522,25 +522,29 @@ impl<T: Format> Format for WithArrow<T> {
 }
 
 #[derive(Debug, Clone, Span, Parse, Format)]
-pub struct WithGuard<T, U, D = GuardDelimiter> {
+pub struct WithGuard<T, U, D = GuardDelimiter, const WHEN_OFFSET: usize = 2> {
     item: T,
-    guard: Maybe<Guard<U, D>>,
+    guard: Maybe<Guard<U, D, WHEN_OFFSET>>,
 }
 
 #[derive(Debug, Clone, Span, Parse)]
-struct Guard<T, D> {
+struct Guard<T, D, const OFFSET: usize = 2> {
     when: WhenKeyword,
     conditions: NonEmptyItems<T, D>,
 }
 
-impl<T: Format, D: Format> Format for Guard<T, D> {
+impl<T: Format, D: Format, const OFFSET: usize> Format for Guard<T, D, OFFSET> {
     fn format(&self, fmt: &mut Formatter) {
-        fmt.subregion(Indent::Offset(2), Newline::IfTooLongOrMultiLine, |fmt| {
-            fmt.add_space();
-            self.when.format(fmt);
-            fmt.add_space();
-            self.conditions.format_multi_line(fmt);
-        });
+        fmt.subregion(
+            Indent::Offset(OFFSET),
+            Newline::IfTooLongOrMultiLine,
+            |fmt| {
+                fmt.add_space();
+                self.when.format(fmt);
+                fmt.add_space();
+                self.conditions.format_multi_line(fmt);
+            },
+        );
     }
 }
 

--- a/src/items/forms.rs
+++ b/src/items/forms.rs
@@ -152,7 +152,7 @@ impl Format for FunSpecItem {
 #[derive(Debug, Clone, Span, Parse)]
 struct SpecClause {
     params: WithArrow<Params<Type>>,
-    r#return: WithGuard<Type, Type, CommaDelimiter>,
+    r#return: WithGuard<Type, Type, CommaDelimiter, 4>,
 }
 
 impl Format for SpecClause {
@@ -569,7 +569,7 @@ mod tests {
             -spec foobar(A) ->
                       {atom(),
                        atom()}
-                        when A :: atom();
+                          when A :: atom();
                         (a) ->
                       b."},
             indoc::indoc! {"

--- a/tests/testdata/long_spec.erl
+++ b/tests/testdata/long_spec.erl
@@ -10,3 +10,8 @@
           {ok, #quz{}} |
           {error, term()} |
           undefined.
+
+
+-spec baz() ->
+          {ok, term()} | {error, Reason} | timeout
+              when Reason :: term().


### PR DESCRIPTION
### Before

```erlang
-spec foo() -> 
          Value
            when Value :: ok.
```

### After

```erlang
-spec foo() -> 
          Value
              when Value :: ok.
```