### PR TITLE
Add rebar3_efmt plugin update check

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -33,10 +33,10 @@ pub fn generate_error_message<P: AsRef<Path>>(
 
 fn get_line_string(text: &str, position: Position) -> &str {
     let offset = position.offset();
-    let line_start = (&text[..offset]).rfind('\n').unwrap_or(0);
-    let line_end = (&text[offset..])
+    let line_start = text[..offset].rfind('\n').unwrap_or(0);
+    let line_end = text[offset..]
         .find('\n')
         .map(|x| x + offset)
         .unwrap_or_else(|| text.len());
-    (&text[line_start..line_end]).trim_matches(char::is_control)
+    text[line_start..line_end].trim_matches(char::is_control)
 }


### PR DESCRIPTION
This PR adds a feature that automatically checks the latest rebar3_efmt plugin version.
When there is a newer version than the local one, a warning log message like the following is emitted.

```console
$ rebar3 efmt --show-files
　===> A new release of rebar3_efmt is available: "0.3.0" -> "0.4.0"
　To use the latest version, please execute the following command:
　$ rebar3 plugins upgrade rebar3_efmt.
```

A new option (flag) `--disable-update-check` is added too, to disable this feature.