### PR TITLE
App application resource file (.app or .app.src) handling

### DIFF
--- a/src/items.rs
+++ b/src/items.rs
@@ -1,4 +1,4 @@
-use crate::format::Format;
+use crate::format::{Format, Formatter};
 use crate::items::components::{Either, Element};
 use crate::items::expressions::{BaseExpr, FullExpr, ListExpr, LiteralExpr};
 use crate::items::tokens::AtomToken;
@@ -113,5 +113,13 @@ impl Expr {
             return Some(x.items());
         }
         None
+    }
+
+    fn try_format_app_file(&self, fmt: &mut Formatter) -> bool {
+        if let FullExpr::Base(BaseExpr::Tuple(x)) = &self.0 {
+            x.try_format_app_file(fmt)
+        } else {
+            false
+        }
     }
 }

--- a/src/items/config.rs
+++ b/src/items/config.rs
@@ -16,6 +16,14 @@ impl Config {
     pub(crate) fn exprs(&self) -> impl Iterator<Item = &Expr> {
         self.terms.iter().map(|t| &t.expr)
     }
+
+    fn try_format_app_file(&self, fmt: &mut Formatter) -> bool {
+        if self.terms.len() != 1 {
+            return false;
+        }
+
+        self.terms[0].expr.try_format_app_file(fmt)
+    }
 }
 
 impl Parse for Config {
@@ -32,6 +40,10 @@ impl Parse for Config {
 
 impl Format for Config {
     fn format(&self, fmt: &mut Formatter) {
+        if self.try_format_app_file(fmt) {
+            return;
+        }
+
         for term in &self.terms {
             term.format(fmt);
             fmt.write_newline();

--- a/src/items/expressions/tuples.rs
+++ b/src/items/expressions/tuples.rs
@@ -1,4 +1,4 @@
-use crate::format::Format;
+use crate::format::{Format, Formatter};
 use crate::items::components::TupleLike;
 use crate::items::tokens::AtomToken;
 use crate::items::Expr;
@@ -12,6 +12,10 @@ pub struct TupleExpr(TupleLike<Expr>);
 impl TupleExpr {
     pub(crate) fn items(&self) -> (Option<&AtomToken>, &[Expr]) {
         self.0.items()
+    }
+
+    pub(crate) fn try_format_app_file(&self, fmt: &mut Formatter) -> bool {
+        self.0.try_format_app_file(fmt)
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,4 @@
-use efmt::items::Module;
+use efmt::items::ModuleOrConfig;
 
 #[test]
 fn format_works() -> anyhow::Result<()> {
@@ -8,7 +8,7 @@ fn format_works() -> anyhow::Result<()> {
         if path.extension().map_or(true, |ext| ext != "erl") {
             continue;
         }
-        let formatted = efmt::Options::new().format_file::<Module, _>(&path)?;
+        let formatted = efmt::Options::new().format_file::<ModuleOrConfig, _>(&path)?;
         let expected = std::fs::read_to_string(&path)?;
         similar_asserts::assert_str_eq!(formatted, expected, "target={:?}", path);
     }

--- a/tests/testdata/test.app.src
+++ b/tests/testdata/test.app.src
@@ -1,0 +1,3 @@
+{application, test,
+ [{foo, bar},
+  {baz, "qux"}]}.


### PR DESCRIPTION
## Before

```erlang
{application, test,
              [{foo, bar},
               {baz, "qux"}]}.
```

## After

```erlang
{application, test,
 [{foo, bar},
  {baz, "qux"}]}.
```