### PR TITLE
Fix indent of comments between seq last item and closing delim

### DIFF
--- a/src/items/components.rs
+++ b/src/items/components.rs
@@ -191,6 +191,7 @@ impl<T: Format, D: Format> Format for NonEmptyItems<T, D> {
                     self.format_items(fmt);
                 });
             }
+            fmt.write_subsequent_comments();
         });
     }
 }
@@ -270,6 +271,7 @@ impl<T: Format + Element, D: Format> Format for MaybePackedItems<T, D> {
             fmt.with_scoped_indent(|fmt| {
                 fmt.set_indent(fmt.column());
                 self.packed_format(fmt);
+                fmt.write_subsequent_comments();
             });
         } else {
             self.0.format(fmt);

--- a/src/items/expressions/components.rs
+++ b/src/items/expressions/components.rs
@@ -70,7 +70,7 @@ impl<Name: Format, const BODY_INDENT: usize> Format for FunctionClause<Name, BOD
 }
 
 /// ([Expr], `,`?)+
-#[derive(Debug, Clone, Span, Parse)]
+#[derive(Debug, Clone, Span, Parse, Format)]
 pub struct Body {
     exprs: NonEmptyItems<Expr, CommaSymbol>,
 }
@@ -78,13 +78,6 @@ pub struct Body {
 impl Body {
     pub(crate) fn exprs(&self) -> &[Expr] {
         self.exprs.items()
-    }
-}
-
-impl Format for Body {
-    fn format(&self, fmt: &mut Formatter) {
-        self.exprs.format(fmt);
-        fmt.write_subsequent_comments();
     }
 }
 

--- a/tests/testdata/comments2.erl
+++ b/tests/testdata/comments2.erl
@@ -13,4 +13,8 @@ foo(B) ->
             ok
             %% comment2
     end,
+    [a,
+     b
+     %% c
+     ],
     world.


### PR DESCRIPTION
## Before

```erlang
[a,
 b
%% c
]
```

## After

```erlang
[a,
 b
 %% c
 ]
```