### PR TITLE
Allow newlines just after function call open parenthes

### DIFF
--- a/src/items/expressions/calls.rs
+++ b/src/items/expressions/calls.rs
@@ -12,7 +12,7 @@ use crate::span::Span;
 /// - $MODULE: [Expr] `:`
 /// - $NAME: [Expr]
 /// - $ARG: [Expr]
-#[derive(Debug, Clone, Span, Parse, Format)]
+#[derive(Debug, Clone, Span, Parse)]
 pub struct FunctionCallExpr {
     module: Maybe<(BaseExpr, ColonSymbol)>,
     function: BaseExpr,
@@ -37,6 +37,17 @@ impl ResumeParse<(BaseExpr, bool)> for FunctionCallExpr {
                 args: ts.parse()?,
             })
         }
+    }
+}
+
+impl Format for FunctionCallExpr {
+    fn format(&self, fmt: &mut Formatter) {
+        fmt.with_scoped_indent(|fmt| {
+            fmt.set_indent(fmt.column());
+            self.module.format(fmt);
+            self.function.format(fmt);
+            self.args.format(fmt);
+        });
     }
 }
 
@@ -156,6 +167,18 @@ mod tests {
             indoc::indoc! {"
             foo(A * 10 * B /
                 1_0.0)"},
+            indoc::indoc! {"
+            foo(a,
+                b,
+                c)"},
+            indoc::indoc! {"
+            foo(
+              a, b, c)"},
+            indoc::indoc! {"
+            foo(
+              a,
+              b,
+              c)"},
         ];
         for text in texts {
             crate::assert_format!(text, Expr);

--- a/src/items/macros.rs
+++ b/src/items/macros.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 ///
 /// - $NAME: [AtomToken] | [VariableToken]
 /// - $ARG: [LexicalToken]+
-#[derive(Debug, Clone, Span, Parse, Format)]
+#[derive(Debug, Clone, Span, Parse)]
 pub struct Macro {
     question: QuestionSymbol,
     name: MacroName,
@@ -39,6 +39,17 @@ impl ResumeParse<(QuestionSymbol, MacroName, bool)> for Macro {
                 args: Maybe::parse_none(ts)?,
             })
         }
+    }
+}
+
+impl Format for Macro {
+    fn format(&self, fmt: &mut Formatter) {
+        fmt.with_scoped_indent(|fmt| {
+            fmt.set_indent(fmt.column());
+            self.question.format(fmt);
+            self.name.format(fmt);
+            self.args.format(fmt);
+        });
     }
 }
 
@@ -412,6 +423,24 @@ mod tests {
             -define(FOO(X), X).
             -define(BAR(),
                     ?FOO(baz),).
+            "},
+            indoc::indoc! {"
+            foo() ->
+                ?FOO(
+                  a, b, c).
+            "},
+            indoc::indoc! {"
+            foo() ->
+                ?FOO(
+                  a,
+                  b,
+                  c).
+            "},
+            indoc::indoc! {"
+            foo() ->
+                ?FOO(a,
+                     b,
+                     c).
             "},
         ];
         for text in texts {


### PR DESCRIPTION
## Before

```erlang
foo(a, b, c)
```

### After

```erlang
foo(a, b, c)

%% or 

foo(
  a, b, c)
```