### PR TITLE
Fix wrong `when` indent in `-spec`

### DIFF
--- a/src/items/components.rs
+++ b/src/items/components.rs
@@ -507,6 +507,12 @@ pub struct Guard<T, D = GuardDelimiter> {
     conditions: NonEmptyItems<T, D>,
 }
 
+impl<T, D> Guard<T, D> {
+    pub fn conditions(&self) -> &NonEmptyItems<T, D> {
+        &self.conditions
+    }
+}
+
 impl<T: Format, D: Format> Format for Guard<T, D> {
     fn format(&self, fmt: &mut Formatter) {
         self.when.format(fmt);

--- a/src/items/forms.rs
+++ b/src/items/forms.rs
@@ -205,8 +205,8 @@ impl<const INDENT: usize> Format for SpecClause<INDENT> {
 
             // 'Guard'
             if let Some(guard) = self.guard.get() {
-                if fmt.has_newline_until(guard) {
-                    fmt.set_indent(fmt.indent() + 4);
+                if fmt.has_newline_until(guard.conditions()) {
+                    fmt.set_indent(INDENT + 8);
                     fmt.write_newline();
                 } else {
                     fmt.write_space();
@@ -632,6 +632,9 @@ mod tests {
                           when A :: atom();
                         (a) ->
                       b."},
+            indoc::indoc! {"
+            -spec foobar(A) -> {atom(), atom()}
+                          when A :: atom()."},
             indoc::indoc! {"
             -spec foo:bar() ->
                       baz()."},


### PR DESCRIPTION
## Before

```erlang
-spec foo(A) -> bar
                when A :: atom().
```

## After

```erlang
-spec foo(A) -> bar
              when A :: atom().
```
 