### PR TITLE
Don't insert a newline before the last element of an improper list

### DIFF
--- a/src/items/components.rs
+++ b/src/items/components.rs
@@ -247,7 +247,7 @@ impl<T, D> Items<T, D> {
 }
 
 #[derive(Debug, Clone, Span, Parse)]
-struct MaybePackedItems<T, D = CommaSymbol>(Items<T, D>);
+pub struct MaybePackedItems<T, D = CommaSymbol>(Items<T, D>);
 
 impl<T, D> MaybePackedItems<T, D> {
     pub(crate) fn items(&self) -> &[T] {

--- a/src/items/expressions.rs
+++ b/src/items/expressions.rs
@@ -32,7 +32,7 @@ pub use self::bitstrings::{BitstringComprehensionExpr, BitstringConstructExpr};
 pub use self::blocks::{BeginExpr, CaseExpr, CatchExpr, IfExpr, ReceiveExpr, TryExpr};
 pub use self::calls::{BinaryOpCallExpr, FunctionCallExpr, UnaryOpCallExpr};
 pub use self::functions::{AnonymousFunctionExpr, DefinedFunctionExpr, NamedFunctionExpr};
-pub use self::lists::{ListComprehensionExpr, ListConstructExpr};
+pub use self::lists::{ImproperListConstructExpr, ListComprehensionExpr, ListConstructExpr};
 pub use self::maps::{MapConstructExpr, MapUpdateExpr};
 pub use self::records::{RecordAccessExpr, RecordConstructExpr, RecordIndexExpr, RecordUpdateExpr};
 pub use self::strings::StringExpr;

--- a/src/items/expressions/lists.rs
+++ b/src/items/expressions/lists.rs
@@ -1,23 +1,24 @@
 use crate::format::{Format, Formatter};
-use crate::items::components::ListLike;
+use crate::items::components::{ListLike, MaybePackedItems};
 use crate::items::expressions::components::ComprehensionExpr;
 #[cfg(doc)]
 use crate::items::expressions::components::Qualifier;
-use crate::items::symbols::{CloseSquareSymbol, CommaSymbol, OpenSquareSymbol, VerticalBarSymbol};
+use crate::items::symbols::{CloseSquareSymbol, OpenSquareSymbol, VerticalBarSymbol};
 use crate::items::Expr;
 use crate::parse::Parse;
 use crate::span::Span;
 
-/// [ListConstructExpr] | [ListComprehensionExpr]
+/// [ListConstructExpr] | [ListComprehensionExpr] | [ImproperListConstructExpr]
 #[derive(Debug, Clone, Span, Parse, Format)]
 pub enum ListExpr {
     Construct(ListConstructExpr),
     Comprehension(ListComprehensionExpr),
+    ConstructImproper(ImproperListConstructExpr),
 }
 
-/// `[` ([Expr] (`,` | `|`)?)* `]`
+/// `[` ([Expr] `,`?)* `]`
 #[derive(Debug, Clone, Span, Parse, Format)]
-pub struct ListConstructExpr(ListLike<Expr, ListItemDelimiter>);
+pub struct ListConstructExpr(ListLike<Expr>);
 
 impl ListConstructExpr {
     pub(crate) fn items(&self) -> &[Expr] {
@@ -25,23 +26,26 @@ impl ListConstructExpr {
     }
 }
 
+/// `[` ([Expr] (`,` | `|`)?)* `]`
 #[derive(Debug, Clone, Span, Parse)]
-enum ListItemDelimiter {
-    Comma(CommaSymbol),
-    VerticalBar(VerticalBarSymbol),
+pub struct ImproperListConstructExpr {
+    open: OpenSquareSymbol,
+    items: MaybePackedItems<Expr>,
+    bar: VerticalBarSymbol,
+    last: Expr,
+    close: CloseSquareSymbol,
 }
 
-impl Format for ListItemDelimiter {
+impl Format for ImproperListConstructExpr {
     fn format(&self, fmt: &mut Formatter) {
-        match self {
-            Self::Comma(x) => {
-                x.format(fmt);
-            }
-            Self::VerticalBar(x) => {
-                fmt.write_space();
-                x.format(fmt);
-            }
-        }
+        self.open.format(fmt);
+        self.items.format(fmt);
+        fmt.write_space();
+        self.bar.format(fmt);
+        fmt.write_space();
+        self.last.format(fmt);
+        fmt.set_next_comment_indent(fmt.indent() + 1);
+        self.close.format(fmt);
     }
 }
 
@@ -88,8 +92,7 @@ mod tests {
             "[1, 2 | 3]",
             indoc::indoc! {"
             [1,
-             [[2] | 3] |
-             [4, 5]]"},
+             [[2] | 3] | [4, 5]]"},
         ];
         for text in texts {
             crate::assert_format!(text, Expr);


### PR DESCRIPTION
## Before

```erlang
[1,
 2 |
 3]
```

## After

```erlang
[1,
 2 | 3]
```