### PR TITLE
Don't require a newline before `when` even if the guard conditions contain newlines

### DIFF
--- a/src/items/expressions/components.rs
+++ b/src/items/expressions/components.rs
@@ -35,7 +35,7 @@ impl<Name: Format, const BODY_INDENT: usize> Format for FunctionClause<Name, BOD
 
                 // 'Guard'
                 if let Some(guard) = self.guard.get() {
-                    let newline = fmt.has_newline_until(&guard.end_position());
+                    let newline = fmt.has_newline_until(guard.conditions());
                     if newline {
                         fmt.set_indent(base_indent + BODY_INDENT - 2);
                         fmt.write_newline();

--- a/src/items/forms.rs
+++ b/src/items/forms.rs
@@ -592,7 +592,8 @@ mod tests {
               when is_atom(A) ->
                 bar,
                 baz;
-            foo(_) ->
+            foo(B) when is_integer(B);
+                        is_float(B) ->
                 qux."},
         ];
         for text in texts {


### PR DESCRIPTION
## Before

```erlang
foo() 
  when true;
       false ->
    ok.
```
## After

In addition to the above style, the following one is also allowed:
```erlang
foo() when true;
           false ->
    ok.
```
