### PR TITLE
Fix a bug that extra newlines could be inserted before comments just after forms

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -479,6 +479,15 @@ mod tests {
                 %% comment
                 ok.
             "},
+            indoc::indoc! {"
+            foo() ->
+                foo.
+            %% foo
+
+
+            bar() ->
+                bar.
+            "},
         ];
         for text in texts {
             crate::assert_format!(text, Module);

--- a/src/format.rs
+++ b/src/format.rs
@@ -228,10 +228,15 @@ impl Formatter {
         }
     }
 
-    pub fn write_trailing_comment(&mut self) {
-        let position = self.next_comment_start();
+    pub fn write_subsequent_comments(&mut self) {
+        loop {
+            let position = self.next_comment_start();
+            if self.next_macro_start() <= position
+                || position.line() > self.next_position.line() + 1
+            {
+                break;
+            }
 
-        if position.line() == self.next_position.line() {
             self.write_macros_and_comments(position);
         }
     }

--- a/src/items/forms.rs
+++ b/src/items/forms.rs
@@ -49,7 +49,7 @@ impl Format for Form {
             Form::Export(x) => x.format(fmt),
             Form::Attr(x) => x.format(fmt),
         }
-        fmt.write_trailing_comment();
+        fmt.write_subsequent_comments();
     }
 }
 


### PR DESCRIPTION
## Original code 

```erlang
foo() ->
    foo.
    %% foo

bar() ->
    bar.
```
## Before this PR

```erlang
foo() ->
    foo.


%% foo


bar() ->
    bar.
```

## After this PR

```erlang
foo() ->
    foo.
%% foo


bar() ->
    bar.
```
