### PR TITLE
Remove rebar.config handling from `rebar3_efmt` plugin

### DIFF
--- a/rebar3_efmt/src/rebar3_efmt_prv.erl
+++ b/rebar3_efmt/src/rebar3_efmt_prv.erl
@@ -117,19 +117,6 @@ ensure_efmt_installed() ->
             end
     end.
 
--spec term_to_arg_value(term()) -> string().
-term_to_arg_value(X) ->
-    lists:flatten(io_lib:format("~p", [X])).
-
--spec atom_to_arg_key(atom()) -> string().
-atom_to_arg_key(X) ->
-    case atom_to_list(X) of
-        [C] ->
-            [$-, C];
-        S ->
-            "--" ++ string:replace(S, "_", "-")
-    end.
-
 -spec update_check() -> ok.
 update_check() ->
     Url = "https://github.com/sile/efmt/releases/latest",

--- a/rebar3_efmt/src/rebar3_efmt_prv.erl
+++ b/rebar3_efmt/src/rebar3_efmt_prv.erl
@@ -34,15 +34,8 @@ do(State) ->
         false ->
             ok
     end,
-    Args0 = rebar_state:command_args(State) ++ ["--disable-rebar3-efmt-mode"],
-    Args1 = [case Entry of
-                 {K, V} ->
-                     atom_to_arg_key(K) ++ "=" ++ term_to_arg_value(V);
-                 Flag ->
-                     atom_to_arg_key(Flag)
-             end || Entry <- rebar_state:get(State, efmt, [])] ++ Args0,
-    Args2 = ["-I=" ++ Dir || {i, Dir} <- rebar_state:get(State, erl_opts, [])] ++ Args1,
-    ok = rebar3_efmt_command:execute(Args2 -- ["--disable-update-check"]),
+    Args = rebar_state:command_args(State),
+    ok = rebar3_efmt_command:execute(Args -- ["--disable-update-check"]),
     {ok, State}.
 
 -spec format_error(any()) ->  iolist().


### PR DESCRIPTION
This PR improves consistency of behavior between `$ efmt` and `$ rebar3 efmt`.