### PR TITLE
Use module name as the input file name if the latter isn't provided (i.e., code via stdin)

### DIFF
--- a/src/items/atoms.rs
+++ b/src/items/atoms.rs
@@ -58,3 +58,7 @@ impl_parse!(ExportAtom, "export");
 #[derive(Debug, Clone, Span, Format, Element)]
 pub struct ExportTypeAtom(AtomToken);
 impl_parse!(ExportTypeAtom, "export_type");
+
+#[derive(Debug, Clone, Span, Format, Element)]
+pub struct ModuleAtom(AtomToken);
+impl_parse!(ModuleAtom, "module");

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,7 +290,7 @@ fn format_files(opt: &Opt) -> anyhow::Result<()> {
             .collect::<Vec<_>>()
     };
 
-    if !error_files.is_empty() {
+    if opt.files.len() > 1 && !error_files.is_empty() {
         eprintln!();
         anyhow::bail!(
             "Failed to format the following files:\n{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -290,16 +290,20 @@ fn format_files(opt: &Opt) -> anyhow::Result<()> {
             .collect::<Vec<_>>()
     };
 
-    if opt.files.len() > 1 && !error_files.is_empty() {
-        eprintln!();
-        anyhow::bail!(
-            "Failed to format the following files:\n{}",
-            error_files
-                .iter()
-                .map(|f| format!("- {}", f.to_str().unwrap_or("<unknown>")))
-                .collect::<Vec<_>>()
-                .join("\n"),
-        );
+    if !error_files.is_empty() {
+        if opt.files.len() > 1 {
+            eprintln!();
+            anyhow::bail!(
+                "Failed to format the following files:\n{}",
+                error_files
+                    .iter()
+                    .map(|f| format!("- {}", f.to_str().unwrap_or("<unknown>")))
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            );
+        } else {
+            std::process::exit(1);
+        }
     } else if opt.write {
         log::info!("All files were formatted correctly!");
     }

--- a/src/parse/token_stream.rs
+++ b/src/parse/token_stream.rs
@@ -11,7 +11,7 @@ use crate::span::{Position, Span};
 use erl_tokenize::values::Symbol;
 use erl_tokenize::{PositionRange as _, Tokenizer};
 use std::collections::{BTreeMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -128,6 +128,11 @@ impl TokenStream {
 
     pub fn filepath(&self) -> Option<Arc<PathBuf>> {
         self.path.clone()
+    }
+
+    pub fn set_filepath<P: AsRef<Path>>(&mut self, path: P) {
+        self.tokenizer.set_filepath(&path);
+        self.path = Some(Arc::new(path.as_ref().to_path_buf()));
     }
 
     pub fn contains_comment(&self, span: &impl Span) -> bool {


### PR DESCRIPTION
## Before
```console
$ echo "-module(foo). \nfoo -> ok." | efmt -
[2022-08-18T11:51:00Z ERROR efmt] Failed to format "-"
    Parse failed:
    --> <unknown>:2:5
    2 | foo -> ok.
      |     ^ unexpected token
```

## After
```console
$ echo "-module(foo). \nfoo -> ok." | efmt -
[2022-08-18T11:50:23Z ERROR efmt] Failed to format "-"
    Parse failed:
    --> foo.erl:2:5
    2 | foo -> ok.
      |     ^ unexpected token
```