### PR TITLE
Don't insert a newline before `<-` or `<=` in comprehensions

### DIFF
--- a/src/items/expressions/bitstrings.rs
+++ b/src/items/expressions/bitstrings.rs
@@ -140,8 +140,7 @@ mod tests {
                      true ->
                          X - 10 + $A
                  end>>
-               || <<X:4>>
-                      <= B >>"},
+               || <<X:4>> <= B >>"},
         ];
         for text in texts {
             crate::assert_format!(text, Expr);

--- a/src/items/expressions/components.rs
+++ b/src/items/expressions/components.rs
@@ -10,7 +10,6 @@ use crate::items::Expr;
 use crate::parse::{self, Parse};
 use crate::span::Span;
 use erl_tokenize::values::{Keyword, Symbol};
-use std::cmp::min;
 
 #[derive(Debug, Clone, Span, Parse)]
 pub(crate) struct FunctionClause<Name, const BODY_INDENT: usize = 4> {
@@ -105,14 +104,7 @@ impl Format for Generator {
     fn format(&self, fmt: &mut Formatter) {
         fmt.with_scoped_indent(|fmt| {
             self.pattern.format(fmt);
-
-            if fmt.has_newline_until(&self.sequence) {
-                fmt.set_indent(min(fmt.column(), fmt.indent() + 4));
-                fmt.write_newline();
-            } else {
-                fmt.write_space();
-            }
-
+            fmt.write_space();
             self.delimiter.format(fmt);
             fmt.write_space();
             fmt.set_indent(fmt.column());


### PR DESCRIPTION
### Original code

```erlang
[ X || {A, B, C}
   <- List].
```

### `master` branch

```erlang
[ X || {A, B, C}
           <- List ].
```

### This PR

```erlang
[ X || {A, B, C} <- List ].
```