### PR TITLE
Use the parent dir of target files as the dir for temp files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -444,7 +444,11 @@ fn validate_formatted_text<P: AsRef<Path>>(
 }
 
 fn overwrite<P: AsRef<Path>>(path: P, text: &str) -> anyhow::Result<()> {
-    let mut temp = tempfile::NamedTempFile::new()?;
+    let dir = path
+        .as_ref()
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("failed to get parent dir: {:?}", path.as_ref()))?;
+    let mut temp = tempfile::NamedTempFile::new_in(dir)?;
     temp.write_all(text.as_bytes())?;
     temp.persist(path)?;
     Ok(())


### PR DESCRIPTION
When `$ efmt --write /path/to/file.erl` is executed, the current `master` branch create a temporary file in the system temp dir (e.g., `/tmp/`) to write the formatted result. Then, it renames the temp file with the input file (`/path/to/file.erl` in this case).
A problem is that there is not guarantee that both the input and temp files are located in the same filesystem. If it isn't, the rename operation would fail.
This PR changes the temp file dir to the parent dir of input files to fix this problem.