### PR TITLE
Don't treat as a tagged tuple if there are newlines just after the first atom element

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -17,6 +17,12 @@ impl<T: Format> Format for Box<T> {
     }
 }
 
+impl<T: Format> Format for &T {
+    fn format(&self, fmt: &mut Formatter) {
+        (**self).format(fmt);
+    }
+}
+
 impl<A: Format, B: Format> Format for (A, B) {
     fn format(&self, fmt: &mut Formatter) {
         self.0.format(fmt);

--- a/src/items/expressions/tuples.rs
+++ b/src/items/expressions/tuples.rs
@@ -38,6 +38,11 @@ mod tests {
              {3, 4, 5},
              6,
              {7, 8, 9}}"},
+            indoc::indoc! {"
+            {error,
+             {Foo, Bar,
+              Baz},
+             qux}"},
         ];
         for text in texts {
             crate::assert_format!(text, Expr);


### PR DESCRIPTION
For example, the following code is accepted as a valid style by this PR:
```erlang
{key,
 value}.
```