### PR TITLE
Support map comprehension

### DIFF
--- a/src/items/expressions.rs
+++ b/src/items/expressions.rs
@@ -33,7 +33,7 @@ pub use self::blocks::{BeginExpr, CaseExpr, CatchExpr, IfExpr, ReceiveExpr, TryE
 pub use self::calls::{BinaryOpCallExpr, FunctionCallExpr, UnaryOpCallExpr};
 pub use self::functions::{AnonymousFunctionExpr, DefinedFunctionExpr, NamedFunctionExpr};
 pub use self::lists::{ImproperListConstructExpr, ListComprehensionExpr, ListConstructExpr};
-pub use self::maps::{MapConstructExpr, MapUpdateExpr};
+pub use self::maps::{MapExpr, MapUpdateExpr};
 pub use self::records::{RecordAccessExpr, RecordConstructExpr, RecordIndexExpr, RecordUpdateExpr};
 pub use self::strings::StringExpr;
 pub use self::tuples::TupleExpr;
@@ -42,7 +42,7 @@ pub use self::tuples::TupleExpr;
 pub(crate) enum BaseExpr {
     List(Box<ListExpr>),
     Tuple(Box<TupleExpr>),
-    MapConstruct(Box<MapConstructExpr>),
+    Map(Box<MapExpr>),
     RecordConstructOrIndex(Box<RecordConstructOrIndexExpr>),
     Bitstring(Box<BitstringExpr>),
     Function(Box<FunctionExpr>),
@@ -66,7 +66,7 @@ impl Parse for BaseExpr {
                 Symbol::OpenParen => ts.parse().map(Self::Parenthesized),
                 Symbol::Sharp => {
                     if ts.peek::<(LexicalToken, OpenBraceSymbol)>().is_some() {
-                        ts.parse().map(Self::MapConstruct)
+                        ts.parse().map(Self::Map)
                     } else {
                         ts.parse().map(Self::RecordConstructOrIndex)
                     }

--- a/src/items/expressions/bitstrings.rs
+++ b/src/items/expressions/bitstrings.rs
@@ -124,6 +124,10 @@ mod tests {
                || X <- [1, 2,
                         3] >>"},
             indoc::indoc! {"
+            << <<X, Y>>
+               || X := Y <- [1, 2,
+                             3] >>"},
+            indoc::indoc! {"
             << (foo(X,
                     Y,
                     Z,

--- a/src/items/expressions/components.rs
+++ b/src/items/expressions/components.rs
@@ -134,15 +134,15 @@ impl Format for Generator {
 struct GeneratorDelimiter(Either<LeftArrowSymbol, DoubleLeftArrowSymbol>);
 
 #[derive(Debug, Clone, Span, Parse)]
-pub(crate) struct ComprehensionExpr<Open, Close> {
+pub(crate) struct ComprehensionExpr<Open, Close, Value = Expr> {
     open: Open,
-    value: Expr,
+    value: Value,
     delimiter: DoubleVerticalBarSymbol,
     qualifiers: NonEmptyItems<Qualifier>,
     close: Close,
 }
 
-impl<Open: Format, Close: Format> Format for ComprehensionExpr<Open, Close> {
+impl<Open: Format, Close: Format, Value: Format> Format for ComprehensionExpr<Open, Close, Value> {
     fn format(&self, fmt: &mut Formatter) {
         self.open.format(fmt);
         fmt.with_scoped_indent(|fmt| {

--- a/src/items/expressions/components.rs
+++ b/src/items/expressions/components.rs
@@ -3,7 +3,7 @@ use crate::items::components::{Either, Guard, Maybe, NonEmptyItems, Params};
 use crate::items::keywords;
 use crate::items::symbols::{
     self, CommaSymbol, DoubleLeftArrowSymbol, DoubleVerticalBarSymbol, LeftArrowSymbol,
-    RightArrowSymbol,
+    MapMatchSymbol, RightArrowSymbol,
 };
 use crate::items::tokens::LexicalToken;
 use crate::items::Expr;
@@ -88,14 +88,31 @@ impl Format for Body {
 }
 
 /// ((`$GENERATOR` | `$FILTER`) `,`?)+
-/// - $GENERATOR: `Expr` (`<-` | `<=`) `Expr`
+/// - $GENERATOR: (`Expr` | `Expr` `:=` `Expr`) `<-` `Expr` | `Expr` `<=` `Expr`
 /// - $FILTER: `Expr`
 #[derive(Debug, Clone, Span, Parse, Format)]
 pub struct Qualifier(Either<Generator, Expr>);
 
 #[derive(Debug, Clone, Span, Parse)]
+pub struct MapGeneratorPattern {
+    key: Expr,
+    delimiter: MapMatchSymbol,
+    value: Expr,
+}
+
+impl Format for MapGeneratorPattern {
+    fn format(&self, fmt: &mut Formatter) {
+        self.key.format(fmt);
+        fmt.write_space();
+        self.delimiter.format(fmt);
+        fmt.write_space();
+        self.value.format(fmt);
+    }
+}
+
+#[derive(Debug, Clone, Span, Parse)]
 struct Generator {
-    pattern: Expr,
+    pattern: Either<MapGeneratorPattern, Expr>,
     delimiter: GeneratorDelimiter,
     sequence: Expr,
 }

--- a/src/items/expressions/lists.rs
+++ b/src/items/expressions/lists.rs
@@ -105,6 +105,8 @@ mod tests {
             indoc::indoc! {"
             [ X || X <- [1, 2] ]"},
             indoc::indoc! {"
+            [ {K, V} || K := V <- [1, 2] ]"},
+            indoc::indoc! {"
             [ X
               || X <- [1, 2,
                        3] ]"},

--- a/src/items/expressions/maps.rs
+++ b/src/items/expressions/maps.rs
@@ -1,15 +1,50 @@
-use crate::format::Format;
+use crate::format::{Format, Formatter};
 use crate::items::components::MapLike;
-use crate::items::symbols::SharpSymbol;
+use crate::items::symbols::{
+    CloseBraceSymbol, DoubleRightArrowSymbol, OpenBraceSymbol, SharpSymbol,
+};
 use crate::items::Expr;
 use crate::parse::{self, Parse, ResumeParse};
 use crate::span::Span;
+
+use super::components::ComprehensionExpr;
+
+#[derive(Debug, Clone, Span, Parse, Format)]
+pub enum MapExpr {
+    Construct(MapConstructExpr),
+    Comprehension(MapComprehensionExpr),
+}
 
 /// `#` `{` (`$ENTRY`, `,`?)* `}`
 ///
 /// - $ENTRY: `Expr` `=>` `Expr`
 #[derive(Debug, Clone, Span, Parse, Format)]
 pub struct MapConstructExpr(MapLike<SharpSymbol, Expr>);
+
+/// `#` `{` `$ENTRY` || ([Qualifier] `,`?)+ `}`
+///
+/// - $ENTRY: `Expr` `=>` `Expr`
+#[derive(Debug, Clone, Span, Parse, Format)]
+pub struct MapComprehensionExpr(
+    ComprehensionExpr<(SharpSymbol, OpenBraceSymbol), CloseBraceSymbol, MapComprehensionValue>,
+);
+
+#[derive(Debug, Clone, Span, Parse)]
+struct MapComprehensionValue {
+    key: Expr,
+    delimiter: DoubleRightArrowSymbol,
+    value: Expr,
+}
+
+impl Format for MapComprehensionValue {
+    fn format(&self, fmt: &mut Formatter) {
+        self.key.format(fmt);
+        fmt.write_space();
+        self.delimiter.format(fmt);
+        fmt.write_space();
+        self.value.format(fmt);
+    }
+}
 
 /// `$VALUE` `#` `{` (`$ENTRY`, `,`?)* `}`
 ///
@@ -46,6 +81,17 @@ mod tests {
              }"},
             indoc::indoc! {"
             #{1 => 2, 333 => {444, 55}}"},
+        ];
+        for text in texts {
+            crate::assert_format!(text, Expr);
+        }
+    }
+
+    #[test]
+    fn map_comprehension_works() {
+        let texts = [
+            "#{ Key => Value || Key := Value <- MapOrIterator }",
+            "#{ K => V || <<K, V>> <= Binary }",
         ];
         for text in texts {
             crate::assert_format!(text, Expr);


### PR DESCRIPTION
Map comprehension is proposed in [EEP 58](https://www.erlang.org/eeps/eep-0058) and has been implemented   by [OTP 26.0-rc1](https://github.com/erlang/otp/releases/tag/OTP-26.0-rc1).