### PR TITLE
[rebar3_efmt] Explicitly specify `{ssl, [{verify, verify_none}]}` option

### DIFF
--- a/rebar3_efmt/src/rebar3_efmt_command.erl
+++ b/rebar3_efmt/src/rebar3_efmt_command.erl
@@ -70,7 +70,7 @@ install_prebuilt_binary(Version) ->
             Url = "https://github.com/sile/efmt/releases/download/" ++ Version ++
                 "/efmt-" ++ Version ++ "." ++ Arch,
             rebar_api:info("Pre-built binary URL: ~p", [Url]),
-            case httpc:request(Url) of
+            case httpc:request(get, {Url, []}, [{ssl, [{verify, verify_none}]}], []) of
                 {error, Reason} ->
                     {error, {http_get_failed, Reason}};
                 {ok, {{_, 200, _}, _Header, Body}} ->

--- a/rebar3_efmt/src/rebar3_efmt_prv.erl
+++ b/rebar3_efmt/src/rebar3_efmt_prv.erl
@@ -112,7 +112,7 @@ ensure_efmt_installed() ->
 -spec update_check() -> ok.
 update_check() ->
     Url = "https://github.com/sile/efmt/releases/latest",
-    case httpc:request(get, {Url, []}, [{autoredirect, false}, {ssl, [{log_level, error}]}], []) of
+    case httpc:request(get, {Url, []}, [{autoredirect, false}, {ssl, [{log_level, error}, {verify, verify_none}]}], []) of
         {error, Reason} ->
             rebar_api:warn("Failed to check update due to HTTP error: url=~p, reason=~p", [Url, Reason]),
             ok;


### PR DESCRIPTION
Erlang OTP 26-rc2 has changed the default value of `verify` option (see [the release note](https://www.erlang.org/news/162#ssl)), and `rebar3_efmt` plugin installation gets failed due to the following error if OTP 26-rc2 is used:
```erlang
===> No `efmt` binary found. Trying installing a pre-built binary.
===> Pre-built binary URL: "https://github.com/sile/efmt/releases/download/0.14.0/efmt-0.14.0.aarch64-apple-darwin"
===> Failed to install a pre-built binary ({http_get_failed,
                                                       {failed_connect,
                                                        [{to_address,
                                                          {"github.com",443}},
                                                         {inet,
                                                          [inet],
                                                          {options,
                                                           {verify,
                                                            {missing_dep_cacertfile_or_cacerts}}}}]}}).
```

This PR fixes this issue by explicitly specifying `{ssl, [{verify, verify_none}]}` option to `httpc:request()`.