### PR TITLE
Support OTP-27.0-rc1 (triple-quoted strings and sigil string literals)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "erl_tokenize"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2146a64debc5e560a78a4936443925ca052de20b43e02fdc1504b655a8cd932"
+checksum = "a24ec1135ba7491998b4329f9e534f530be0ec04700f98a88d8fe837e6ae7d97"
 dependencies = [
  "num",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "erl_tokenize"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24ec1135ba7491998b4329f9e534f530be0ec04700f98a88d8fe837e6ae7d97"
+checksum = "c83661c583875d5f3fd5a0196a358518341f449cb835642ed409f23c4c9dd58b"
 dependencies = [
  "num",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["/rebar3_efmt/"]
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-erl_tokenize = "0.5"
+erl_tokenize = "0.6"
 efmt_core = { path = "efmt_core", version = "0.1.0" }
 env_logger = "0.11"
 log = "0.4"

--- a/efmt_core/Cargo.toml
+++ b/efmt_core/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/sile/efmt"
 readme = "README.md"
 
 [dependencies]
-erl_tokenize = "0.5"
+erl_tokenize = "0.6"
 efmt_derive = { path = "../efmt_derive", version = "0.1.0" }
 log = "0.4"
 thiserror = "1"

--- a/efmt_core/src/items/expressions.rs
+++ b/efmt_core/src/items/expressions.rs
@@ -3,7 +3,8 @@ use crate::format::Format;
 use crate::items::components::{Either, Element, Parenthesized};
 use crate::items::symbols::OpenBraceSymbol;
 use crate::items::tokens::{
-    AtomToken, CharToken, FloatToken, IntegerToken, LexicalToken, SymbolToken, VariableToken,
+    AtomToken, CharToken, FloatToken, IntegerToken, LexicalToken, SigilStringToken, SymbolToken,
+    VariableToken,
 };
 use crate::items::Expr;
 use crate::parse::{self, Parse};
@@ -190,13 +191,14 @@ impl Element for FullExpr {
     }
 }
 
-/// [AtomToken] | [CharToken] | [FloatToken] | [IntegerToken] | [VariableToken] | [StringExpr]
+/// [AtomToken] | [CharToken] | [FloatToken] | [IntegerToken] | [VariableToken] | [StringExpr] | [SigilStringToken]
 #[derive(Debug, Clone, Span, Parse, Format, Element)]
 pub enum LiteralExpr {
     Atom(AtomToken),
     Char(CharToken),
     Float(FloatToken),
     Integer(IntegerToken),
+    SigilString(SigilStringToken),
     String(StringExpr),
     Variable(VariableToken),
 }

--- a/efmt_core/src/items/tokens.rs
+++ b/efmt_core/src/items/tokens.rs
@@ -13,6 +13,7 @@ pub enum LexicalToken {
     Float(FloatToken),
     Integer(IntegerToken),
     Keyword(KeywordToken),
+    SigilString(SigilStringToken),
     String(StringToken),
     Symbol(SymbolToken),
     Variable(VariableToken),
@@ -26,6 +27,7 @@ impl LexicalToken {
             Self::Float(x) => (&mut x.start, &mut x.end),
             Self::Integer(x) => (&mut x.start, &mut x.end),
             Self::Keyword(x) => (&mut x.start, &mut x.end),
+            Self::SigilString(x) => (&mut x.start, &mut x.end),
             Self::String(x) => (&mut x.start, &mut x.end),
             Self::Symbol(x) => (&mut x.start, &mut x.end),
             Self::Variable(x) => (&mut x.start, &mut x.end),
@@ -187,6 +189,26 @@ impl KeywordToken {
 }
 
 impl_traits!(KeywordToken, Keyword);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SigilStringToken {
+    start: Position,
+    end: Position,
+}
+
+impl SigilStringToken {
+    pub fn new(start: Position, end: Position) -> Self {
+        Self { start, end }
+    }
+}
+
+impl_traits!(SigilStringToken, SigilString);
+
+impl Element for SigilStringToken {
+    fn is_packable(&self) -> bool {
+        true
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StringToken {

--- a/efmt_core/src/parse/token_stream.rs
+++ b/efmt_core/src/parse/token_stream.rs
@@ -4,7 +4,7 @@ use crate::items::macros::{Macro, MacroName};
 use crate::items::symbols::{OpenParenSymbol, QuestionSymbol};
 use crate::items::tokens::{
     AtomToken, CharToken, CommentToken, FloatToken, IntegerToken, KeywordToken, LexicalToken,
-    StringToken, SymbolToken, VariableToken,
+    SigilStringToken, StringToken, SymbolToken, VariableToken,
 };
 use crate::parse::{Error, Parse, Result, ResumeParse};
 use crate::span::{Position, Span};
@@ -246,6 +246,9 @@ impl TokenStream {
                 }
                 erl_tokenize::Token::Keyword(x) => {
                     KeywordToken::new(x.value(), start_position, end_position).into()
+                }
+                erl_tokenize::Token::SigilString(_) => {
+                    SigilStringToken::new(start_position, end_position).into()
                 }
                 erl_tokenize::Token::String(x) => {
                     StringToken::new(x.value(), start_position, end_position).into()

--- a/tests/testdata/otp27_strings.erl
+++ b/tests/testdata/otp27_strings.erl
@@ -1,0 +1,29 @@
+-module(otp27_strings).
+
+-doc """
+    First line
+    Second line with "\*not emphasized\* Markdown"
+    Third line
+    """.
+
+
+triple_quoted_strings() ->
+    X = <<"""
+        Line 1
+        Line 2
+        """/utf8>>,
+    X = """"
+        ++ foo() ++
+        """",
+    ok.
+
+
+sigil_strings() ->
+    ~"abc\d",
+    ~'abc"d',
+    ~b[abc"d],
+    ~R/^from: /i,
+    ~""""
+     ++ foo() ++
+     """",
+    ok.


### PR DESCRIPTION
This PR adds support for the following new language features introduced in [OTP-27.0-rc1](https://github.com/erlang/otp/releases/tag/OTP-27.0-rc1):
```
- Triple-Quoted Strings has been implemented as per EEP 64 to allow 
   a string to encompass a complete paragraph.
- Adjacent string literals without intervening white space is now a syntax error, 
   to avoid possible confusion with triple-quoted strings.
- Sigils on string literals (both ordinary and triple-quoted) have been implemented as per EEP 66.
  - For example, ~"Björn" or ~b"Björn" are now equivalent to <<"Björn"/utf8>>.
```