### PR TITLE
Fix the issue where default input files may include non-existing files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -198,6 +208,7 @@ dependencies = [
  "efmt_core",
  "env_logger",
  "erl_tokenize",
+ "ignore",
  "log",
  "rayon",
  "regex",
@@ -297,6 +308,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "globset"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da3b9b5b85bd66f31093f8c408b90a74431672542466497dcbdfdc02034be1"
+dependencies = [
+ "aho-corasick",
+ "bstr 1.9.1",
+ "log",
+ "regex-automata 0.4.7",
+ "regex-syntax",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +331,22 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "ignore"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b46810df39e66e925525d6e38ce1e7f6e1d208f72dc39757880fcb66e2c58af1"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.7",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indoc"
@@ -513,6 +553,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,7 +587,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
 dependencies = [
- "bstr",
+ "bstr 0.2.17",
  "unicode-segmentation",
 ]
 
@@ -618,6 +667,25 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ similar = { version= "2", features = ["inline"] }
 tempfile = "3"
 regex = "1.6.0"
 colored = "2.1.0"
+ignore = "0.4.22"
 
 [dev-dependencies]
 similar-asserts = "1"

--- a/src/files.rs
+++ b/src/files.rs
@@ -80,8 +80,8 @@ pub fn collect_default_target_files() -> anyhow::Result<Vec<PathBuf>> {
         let entry = result?;
         if entry.file_type().map_or(false, |t| t.is_file()) {
             let path = entry.path();
-            if is_format_target(&path) {
-                let path = path.strip_prefix("./").unwrap_or(&path).to_path_buf();
+            if is_format_target(path) {
+                let path = path.strip_prefix("./").unwrap_or(path).to_path_buf();
                 files.push(path);
             }
         }

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,7 +1,7 @@
 use efmt_core::items::{Config, Expr};
 use efmt_core::parse::TokenStream;
+use ignore::Walk;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 pub fn find_rebar_config_dir() -> Option<PathBuf> {
     let mut dir = std::env::current_dir().ok()?;
@@ -75,65 +75,13 @@ impl RebarConfigValue {
 }
 
 pub fn collect_default_target_files() -> anyhow::Result<Vec<PathBuf>> {
-    let current_dir = std::env::current_dir()?;
-    if is_git_repository(&current_dir) {
-        collect_files_with_git(is_format_target)
-    } else {
-        collect_files_without_git(current_dir, is_format_target)
-    }
-}
-
-fn collect_files_with_git<F>(is_target: F) -> anyhow::Result<Vec<PathBuf>>
-where
-    F: Fn(&Path) -> bool,
-{
     let mut files = Vec::new();
-    let args_list = [
-        &["ls-files"][..],
-        &["ls-files", "--others", "--exclude-standard"][..],
-    ];
-    for args in args_list {
-        let output = Command::new("git").args(args).output()?;
-        anyhow::ensure!(
-            output.status.success(),
-            "Failed to execute `$ git {}` command.\n{}",
-            Vec::from(args).join(" "),
-            String::from_utf8_lossy(&output.stderr)
-        );
-        for file in String::from_utf8(output.stdout)?.split('\n') {
-            if file.is_empty() {
-                continue;
-            }
-
-            let path = PathBuf::from(file);
-            if !is_target(&path) {
-                continue;
-            }
-            files.push(path);
-        }
-    }
-    Ok(files)
-}
-
-fn collect_files_without_git<P: AsRef<Path>, F>(
-    root_dir: P,
-    is_target: F,
-) -> anyhow::Result<Vec<PathBuf>>
-where
-    F: Fn(&Path) -> bool,
-{
-    let mut files = Vec::new();
-    let mut stack = vec![root_dir.as_ref().to_path_buf()];
-    while let Some(dir) = stack.pop() {
-        for entry in std::fs::read_dir(dir)? {
-            let entry = entry?;
-            if entry.file_type()?.is_dir() {
-                stack.push(entry.path());
-            } else if entry.file_type()?.is_file() {
-                let path = entry.path();
-                if is_target(&path) {
-                    files.push(path);
-                }
+    for result in Walk::new("./") {
+        let entry = result?;
+        if entry.file_type().map_or(false, |t| t.is_file()) {
+            let path = entry.path();
+            if is_format_target(&path) {
+                files.push(path.to_path_buf());
             }
         }
     }
@@ -149,17 +97,4 @@ fn is_format_target(path: &Path) -> bool {
                 || n.ends_with(".hrl")
                 || n.ends_with(".app.src")
         })
-}
-
-fn is_git_repository<P: AsRef<Path>>(dir: P) -> bool {
-    let mut dir = dir.as_ref();
-    while !dir.join(".git/").exists() {
-        if let Some(parent) = dir.parent() {
-            dir = parent;
-        } else {
-            return false;
-        }
-    }
-    log::debug!("Found `.git` in {:?}", dir);
-    true
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -81,7 +81,8 @@ pub fn collect_default_target_files() -> anyhow::Result<Vec<PathBuf>> {
         if entry.file_type().map_or(false, |t| t.is_file()) {
             let path = entry.path();
             if is_format_target(&path) {
-                files.push(path.to_path_buf());
+                let path = path.strip_prefix("./").unwrap_or(&path).to_path_buf();
+                files.push(path);
             }
         }
     }


### PR DESCRIPTION
Closes #97 

Copilot Generated Summary
-----------------------------

This pull request primarily focuses on simplifying the file collection process in the `src/files.rs` file and adding a new dependency in the `Cargo.toml` file. The most significant changes include the addition of the `ignore` crate to the project dependencies, the use of the `Walk` struct from the `ignore` crate to collect files, and the removal of several functions related to file collection that are no longer necessary.

Dependency addition:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R25): Added `ignore` crate version "0.4.22" to the project dependencies. This crate provides the `Walk` struct used for file collection.

File collection simplification:

* [`src/files.rs`](diffhunk://#diff-5bf5ae12e63725209487d4de26d9a2bd9696e7beffb5cf984898c8d864d3721aR3-L4): Imported the `Walk` struct from the `ignore` crate.
* [`src/files.rs`](diffhunk://#diff-5bf5ae12e63725209487d4de26d9a2bd9696e7beffb5cf984898c8d864d3721aL78-L139): Simplified the `collect_default_target_files` function by using the `Walk` struct to collect files instead of the previous method, which involved checking if the current directory is a git repository and collecting files differently based on that. Removed the `collect_files_with_git` and `collect_files_without_git` functions as they are no longer necessary.
* [`src/files.rs`](diffhunk://#diff-5bf5ae12e63725209487d4de26d9a2bd9696e7beffb5cf984898c8d864d3721aL153-L165): Removed the `is_git_repository` function as it is no longer needed due to the changes in the file collection process.