### PR TITLE
Enable formatting of `?assertMatch()` and `?assertNotMatch()` macros even when they contain `when` in the pattern

### DIFF
--- a/efmt_core/src/items/macros.rs
+++ b/efmt_core/src/items/macros.rs
@@ -608,7 +608,9 @@ mod tests {
     fn assert_match() {
         let texts = [indoc::indoc! {"
             foo() ->
-                ?assertMatch(ok when true, Value).
+                ?assertMatch(ok when true, Value),
+                ?assertNotMatch(ok when true, Value),
+                ok.
             "}];
         for text in texts {
             crate::assert_format!(text, Module);

--- a/efmt_core/src/items/macros.rs
+++ b/efmt_core/src/items/macros.rs
@@ -603,4 +603,15 @@ mod tests {
             crate::assert_format!(text, Module);
         }
     }
+
+    #[test]
+    fn assert_match() {
+        let texts = [indoc::indoc! {"
+            foo() ->
+                ?assertMatch(ok when true, Value).
+            "}];
+        for text in texts {
+            crate::assert_format!(text, Module);
+        }
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/sile/efmt/issues/98

Copilot Generated Summary
-----------------------------

This pull request primarily focuses on changes in two files: `efmt_core/src/items/macros.rs` and `efmt_core/src/parse/token_stream.rs`. The changes in `macros.rs` involve parsing and formatting improvements for `MacroArg`, as well as the addition of a new test for `assert_match`. In `token_stream.rs`, the changes revolve around the expansion of macros with arguments and predefined macros.

Parsing and Formatting Improvements:

* [`efmt_core/src/items/macros.rs`](diffhunk://#diff-a50aa23e35231efb90aef27a018c4821b786851bd41c227ec7fd8c4c6aa8d6f9R1): Imported `Guard` from `components` for use in the `MacroArg` implementation.
* [`efmt_core/src/items/macros.rs`](diffhunk://#diff-a50aa23e35231efb90aef27a018c4821b786851bd41c227ec7fd8c4c6aa8d6f9L273-R290): Modified the `MacroArg` implementation to parse and format `Expr` and `Guard<Expr>`, and improved the handling of indentation and spacing.
* [`efmt_core/src/items/macros.rs`](diffhunk://#diff-a50aa23e35231efb90aef27a018c4821b786851bd41c227ec7fd8c4c6aa8d6f9R618-R633): Added a new test `assert_match` to verify the formatting of match assertions.

Macro Expansion Improvements:

* [`efmt_core/src/parse/token_stream.rs`](diffhunk://#diff-e787f4b15a65d0a3f6b7743e6c9cb33a597ebe26394b85b9a26ac7e66dd7c571L323-R332): Modified `expand_macro_with_args` to accept a function `f` that retrieves a `MacroDefine` for a given key. [[1]](diffhunk://#diff-e787f4b15a65d0a3f6b7743e6c9cb33a597ebe26394b85b9a26ac7e66dd7c571L323-R332) [[2]](diffhunk://#diff-e787f4b15a65d0a3f6b7743e6c9cb33a597ebe26394b85b9a26ac7e66dd7c571L339-R344)
* [`efmt_core/src/parse/token_stream.rs`](diffhunk://#diff-e787f4b15a65d0a3f6b7743e6c9cb33a597ebe26394b85b9a26ac7e66dd7c571L374-R391): Updated the handling of predefined macros to accommodate macros with arguments and those without.
* [`efmt_core/src/parse/token_stream.rs`](diffhunk://#diff-e787f4b15a65d0a3f6b7743e6c9cb33a597ebe26394b85b9a26ac7e66dd7c571L454-R479): Updated `get_predefined_macro` to return a tuple indicating whether the macro has arguments and the replacement tokens. Added support for `assertMatch` and `assertNotMatch` predefined macros.