### PR TITLE
Add support for formatting escript files

### DIFF
--- a/efmt_core/src/lib.rs
+++ b/efmt_core/src/lib.rs
@@ -7,7 +7,7 @@ pub mod span;
 pub fn format_text<T: crate::parse::Parse + crate::format::Format>(
     text: &str,
 ) -> crate::parse::Result<String> {
-    let tokenizer = erl_tokenize::Tokenizer::new(text.to_owned());
+    let tokenizer = crate::parse::Tokenizer::new(text.to_owned());
     let mut ts = crate::parse::TokenStream::new(tokenizer);
     let item: T = ts.parse()?;
     let mut formatter = crate::format::Formatter::new(ts);

--- a/efmt_core/src/parse.rs
+++ b/efmt_core/src/parse.rs
@@ -4,11 +4,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 pub use self::token_stream::TokenStream;
+pub use self::tokenizer::Tokenizer;
 
 /// A procedural macro to derive [Parse].
 pub use efmt_derive::Parse;
 
 pub(crate) mod token_stream;
+pub(crate) mod tokenizer;
 
 /// Possible errors.
 #[derive(Debug, Clone, thiserror::Error)]

--- a/efmt_core/src/parse.rs
+++ b/efmt_core/src/parse.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 pub use self::token_stream::TokenStream;
-pub use self::tokenizer::Tokenizer;
+pub use self::tokenizer::{TokenOrShebang, Tokenizer};
 
 /// A procedural macro to derive [Parse].
 pub use efmt_derive::Parse;

--- a/efmt_core/src/parse/token_stream.rs
+++ b/efmt_core/src/parse/token_stream.rs
@@ -6,17 +6,18 @@ use crate::items::tokens::{
     AtomToken, CharToken, CommentToken, FloatToken, IntegerToken, KeywordToken, LexicalToken,
     SigilStringToken, StringToken, SymbolToken, VariableToken,
 };
+use crate::parse::Tokenizer;
 use crate::parse::{Error, Parse, Result, ResumeParse};
 use crate::span::{Position, Span};
 use erl_tokenize::values::Symbol;
-use erl_tokenize::{PositionRange as _, Tokenizer};
+use erl_tokenize::PositionRange as _;
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct TokenStream {
-    tokenizer: Tokenizer<String>,
+    tokenizer: Tokenizer,
     tokens: Vec<LexicalToken>,
     current_token_index: usize,
     comments: BTreeMap<Position, CommentToken>,
@@ -33,7 +34,7 @@ pub struct TokenStream {
 }
 
 impl TokenStream {
-    pub fn new(tokenizer: Tokenizer<String>) -> Self {
+    pub fn new(tokenizer: Tokenizer) -> Self {
         let text = Arc::new(tokenizer.text().to_owned());
         let path = tokenizer
             .next_position()

--- a/efmt_core/src/parse/tokenizer.rs
+++ b/efmt_core/src/parse/tokenizer.rs
@@ -1,15 +1,29 @@
-use erl_tokenize::{Position, Token};
+use erl_tokenize::{Position, PositionRange, Token};
 use std::path::Path;
 
 #[derive(Debug)]
 pub struct Tokenizer {
+    shebang_end_position: Option<Position>,
     inner: erl_tokenize::Tokenizer<String>,
 }
 
 impl Tokenizer {
     pub fn new(text: String) -> Self {
+        let mut inner = erl_tokenize::Tokenizer::new(text);
+        let shebang_end_position = if inner.text().starts_with("#!") && inner.text().contains('\n')
+        {
+            let mut line_end_position = Position::new();
+            while inner.consume_char() != Some('\n') {
+                line_end_position = inner.next_position();
+            }
+            inner.set_position(line_end_position.clone());
+            Some(line_end_position)
+        } else {
+            None
+        };
         Tokenizer {
-            inner: erl_tokenize::Tokenizer::new(text),
+            shebang_end_position,
+            inner,
         }
     }
 
@@ -27,9 +41,36 @@ impl Tokenizer {
 }
 
 impl Iterator for Tokenizer {
-    type Item = erl_tokenize::Result<Token>;
+    type Item = erl_tokenize::Result<TokenOrShebang>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next()
+        if let Some(position) = self.shebang_end_position.take() {
+            return Some(Ok(TokenOrShebang::Shebang(position)));
+        }
+        self.inner
+            .next()
+            .map(|result| result.map(TokenOrShebang::Token))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum TokenOrShebang {
+    Token(Token),
+    Shebang(Position),
+}
+
+impl PositionRange for TokenOrShebang {
+    fn start_position(&self) -> Position {
+        match self {
+            Self::Token(token) => token.start_position(),
+            Self::Shebang(_) => Position::new(),
+        }
+    }
+
+    fn end_position(&self) -> Position {
+        match self {
+            Self::Token(token) => token.end_position(),
+            Self::Shebang(position) => position.clone(),
+        }
     }
 }

--- a/efmt_core/src/parse/tokenizer.rs
+++ b/efmt_core/src/parse/tokenizer.rs
@@ -1,0 +1,35 @@
+use erl_tokenize::{Position, Token};
+use std::path::Path;
+
+#[derive(Debug)]
+pub struct Tokenizer {
+    inner: erl_tokenize::Tokenizer<String>,
+}
+
+impl Tokenizer {
+    pub fn new(text: String) -> Self {
+        Tokenizer {
+            inner: erl_tokenize::Tokenizer::new(text),
+        }
+    }
+
+    pub fn text(&self) -> &str {
+        self.inner.text()
+    }
+
+    pub fn next_position(&self) -> Position {
+        self.inner.next_position()
+    }
+
+    pub fn set_filepath<P: AsRef<Path>>(&mut self, path: P) {
+        self.inner.set_filepath(path)
+    }
+}
+
+impl Iterator for Tokenizer {
+    type Item = erl_tokenize::Result<Token>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}

--- a/src/files.rs
+++ b/src/files.rs
@@ -97,5 +97,6 @@ fn is_format_target(path: &Path) -> bool {
                 || n.ends_with(".erl")
                 || n.ends_with(".hrl")
                 || n.ends_with(".app.src")
+                || n.ends_with(".escript")
         })
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,5 +1,5 @@
 use efmt_core::items::{Config, Expr};
-use efmt_core::parse::TokenStream;
+use efmt_core::parse::{TokenStream, Tokenizer};
 use ignore::Walk;
 use std::path::{Path, PathBuf};
 
@@ -13,7 +13,7 @@ pub fn find_rebar_config_dir() -> Option<PathBuf> {
 
 pub fn load_rebar_config<P: AsRef<Path>>(path: P) -> anyhow::Result<Vec<RebarConfigValue>> {
     let text = std::fs::read_to_string(&path)?;
-    let mut tokenizer = erl_tokenize::Tokenizer::new(text);
+    let mut tokenizer = Tokenizer::new(text);
     tokenizer.set_filepath(path);
     let mut ts = TokenStream::new(tokenizer);
     let config: Config = ts.parse()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use efmt_core::format::{Format, Formatter};
-use efmt_core::parse::{Parse, TokenStream};
+use efmt_core::parse::{Parse, TokenStream, Tokenizer};
 use std::path::Path;
 
 pub mod diff;
@@ -34,20 +34,17 @@ impl Options {
 
     pub fn format_file<T: Parse + Format, P: AsRef<Path>>(self, path: P) -> anyhow::Result<String> {
         let text = std::fs::read_to_string(&path)?;
-        let mut tokenizer = erl_tokenize::Tokenizer::new(text);
+        let mut tokenizer = Tokenizer::new(text);
         tokenizer.set_filepath(path);
         self.format::<T>(tokenizer)
     }
 
     pub fn format_text<T: Parse + Format>(self, text: &str) -> anyhow::Result<String> {
-        let tokenizer = erl_tokenize::Tokenizer::new(text.to_owned());
+        let tokenizer = Tokenizer::new(text.to_owned());
         self.format::<T>(tokenizer)
     }
 
-    fn format<T: Parse + Format>(
-        self,
-        tokenizer: erl_tokenize::Tokenizer<String>,
-    ) -> anyhow::Result<String> {
+    fn format<T: Parse + Format>(self, tokenizer: Tokenizer) -> anyhow::Result<String> {
         let mut ts = TokenStream::new(tokenizer);
         let item: T = ts.parse()?;
         let mut formatter = Formatter::new(ts);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -7,7 +7,7 @@ fn format_works() -> anyhow::Result<()> {
         let path = entry.path();
         if path
             .extension()
-            .map_or(true, |ext| ext != "erl" && ext != "src")
+            .map_or(true, |ext| ext != "erl" && ext != "src" && ext != "escript")
         {
             continue;
         }

--- a/tests/testdata/factorial.escript
+++ b/tests/testdata/factorial.escript
@@ -1,0 +1,25 @@
+#!/usr/bin/env escript
+%% -*- erlang -*-
+%%! -smp enable -sname factorial -mnesia debug verbose
+%%
+%% From: https://www.erlang.org/docs/17/man/escript
+main([String]) ->
+    try
+        N = list_to_integer(String),
+        F = fac(N),
+        io:format("factorial ~w = ~w\n", [N, F])
+    catch
+        _:_ ->
+            usage()
+    end;
+main(_) ->
+    usage().
+
+
+usage() ->
+    io:format("usage: factorial integer\n"),
+    halt(1).
+
+
+fac(0) -> 1;
+fac(N) -> N * fac(N - 1).

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -36,7 +36,8 @@
           "Erlang"
         ],
         "extensions": [
-          ".erl"
+          ".erl",
+          ".escript"
         ],
         "filenames": [
           "rebar.config"


### PR DESCRIPTION
Closes #101 

Copilot generated summary
------------------------------

This pull request introduces significant changes to the tokenizer implementation in the `efmt_core` library, replacing the use of `erl_tokenize::Tokenizer` with a custom `Tokenizer` that handles shebang lines. Additionally, support for `.escript` files has been added. Here are the most important changes:

### Tokenizer Implementation:

* [`efmt_core/src/lib.rs`](diffhunk://#diff-4ad960fb5bda8d7ef7ed384aa805af85ab9d61a978190f3a056aab9f4a2f2439L10-R10): Replaced `erl_tokenize::Tokenizer` with the new `Tokenizer` in the `format_text` function.
* [`efmt_core/src/parse.rs`](diffhunk://#diff-57f7f88649dc10dfd35c1856f356d9aae269d1da5e4b7e845c3a912f4df11ec9R7-R13): Added `TokenOrShebang` and `Tokenizer` modules and made them publicly available.
* [`efmt_core/src/parse/token_stream.rs`](diffhunk://#diff-e787f4b15a65d0a3f6b7743e6c9cb33a597ebe26394b85b9a26ac7e66dd7c571R9-R22): Updated `TokenStream` to use the new `Tokenizer` and handle `TokenOrShebang` variants. [[1]](diffhunk://#diff-e787f4b15a65d0a3f6b7743e6c9cb33a597ebe26394b85b9a26ac7e66dd7c571R9-R22) [[2]](diffhunk://#diff-e787f4b15a65d0a3f6b7743e6c9cb33a597ebe26394b85b9a26ac7e66dd7c571L36-R39) [[3]](diffhunk://#diff-e787f4b15a65d0a3f6b7743e6c9cb33a597ebe26394b85b9a26ac7e66dd7c571L221-R235) [[4]](diffhunk://#diff-e787f4b15a65d0a3f6b7743e6c9cb33a597ebe26394b85b9a26ac7e66dd7c571L234-R269)
* [`efmt_core/src/parse/tokenizer.rs`](diffhunk://#diff-dd5a5ca710ddc21222c154b3081453233f76c741f874d3a371b70693132f4056R1-R76): Implemented the new `Tokenizer` struct and `TokenOrShebang` enum to handle shebang lines.

### Support for `.escript` Files:

* [`src/files.rs`](diffhunk://#diff-5bf5ae12e63725209487d4de26d9a2bd9696e7beffb5cf984898c8d864d3721aL2-R2): Added `.escript` to the list of format targets and updated the tokenizer usage. [[1]](diffhunk://#diff-5bf5ae12e63725209487d4de26d9a2bd9696e7beffb5cf984898c8d864d3721aL2-R2) [[2]](diffhunk://#diff-5bf5ae12e63725209487d4de26d9a2bd9696e7beffb5cf984898c8d864d3721aL16-R16) [[3]](diffhunk://#diff-5bf5ae12e63725209487d4de26d9a2bd9696e7beffb5cf984898c8d864d3721aR100)
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L2-R2): Updated the `format_file` and `format_text` functions to use the new `Tokenizer`. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L2-R2) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L37-R47)
* [`tests/lib.rs`](diffhunk://#diff-6d1e3ec7ab6aaf7a94f9c1e9a423db6de6e4a1bec380dae17cc6e635f1db8854L10-R10): Added `.escript` to the test file extensions.
* [`tests/testdata/factorial.escript`](diffhunk://#diff-d38190c95509022911260841faca940dc062d4ffba40523dee08b04ceb5d590dR1-R25): Added a test `.escript` file for factorial calculation.