### PR TITLE
Fix a bug when formatting consecutive `-define` directives with single-quoted macro names.

### DIFF
--- a/efmt_core/src/items/module.rs
+++ b/efmt_core/src/items/module.rs
@@ -121,7 +121,11 @@ impl<'a> FormatState<'a> {
         let indent = self
             .pending_constants
             .iter()
-            .map(|define| "-define(".len() + define.macro_name().len() + ", ".len())
+            .map(|define| {
+                let macro_name_len = define.macro_name_token().end_position().offset()
+                    - define.macro_name_token().start_position().offset();
+                "-define(".len() + macro_name_len + ", ".len()
+            })
             .max()
             .expect("unreachable");
 

--- a/tests/testdata/aligned_macro.erl
+++ b/tests/testdata/aligned_macro.erl
@@ -23,3 +23,7 @@
 %% bar
 -define(ccc,  3).
 -define(dddd, 4).
+
+-define('meow-1', "Meow").
+-define('meow-2', "Meow Meow").
+-define('meow-3', "Meow Meow Meow").


### PR DESCRIPTION
Fixes #105 

Copilot Summary
------------------

This pull request includes changes to improve the handling of macro definitions in the `FormatState` struct and updates to the corresponding test data. The most important changes include modifying the way macro name lengths are calculated and adding new test cases for macro definitions.

Improvements to macro definition handling:

* [`efmt_core/src/items/module.rs`](diffhunk://#diff-0da6858cf46ead7b402c0ba11a55825127177d163d1bfaea0cb249f3d13798a5L124-R128): Modified the calculation of macro name lengths to use the start and end positions of the macro name token. This ensures more accurate length calculation.

Updates to test data:

* [`tests/testdata/aligned_macro.erl`](diffhunk://#diff-8409615508bc4c79deb2d2e7b86c87ce94504773ddb5b3616b387a0f014026fdR26-R29): Added new test cases for macro definitions with different lengths and special characters to ensure the updated length calculation works correctly.