### PR TITLE
Fix a bug where an unexpected newline is inserted when formatting `fun () -> ?assertMatch(..., ...) end.`.

### DIFF
--- a/efmt_core/src/format.rs
+++ b/efmt_core/src/format.rs
@@ -176,16 +176,16 @@ impl Formatter {
             return;
         }
 
+        if self.single_line_mode {
+            self.write_space();
+            return;
+        }
+
         if self.skipping {
             self.pending_blank = Some(Blank::Newline(n));
             return;
         }
         self.pending_blank = None;
-
-        if self.single_line_mode {
-            self.write_space();
-            return;
-        }
 
         let indent = self.cancel_last_spaces();
         for c in self.buf.chars().rev() {

--- a/efmt_core/src/items/macros.rs
+++ b/efmt_core/src/items/macros.rs
@@ -618,7 +618,8 @@ mod tests {
 
     #[test]
     fn assert_match() {
-        let texts = [indoc::indoc! {"
+        let texts = [
+            indoc::indoc! {"
             foo() ->
                 ?assertMatch(ok when true, Value),
                 ?assertNotMatch([A, B, C]
@@ -626,7 +627,11 @@ mod tests {
                                        is_integer(C),
                                 Value),
                 ok.
-            "}];
+            "},
+            indoc::indoc! {"
+            foo() -> fun() -> ?assertMatch(ok, Value) end.
+            "},
+        ];
         for text in texts {
             crate::assert_format!(text, Module);
         }


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes changes to the `efmt_core` module to improve the formatting logic and enhance the test coverage. The most important changes include modifying the `Formatter` implementation to handle single-line mode and skipping logic more effectively, and updating the test cases to include additional scenarios for macro formatting.

Improvements to formatting logic:

* [`efmt_core/src/format.rs`](diffhunk://#diff-387b384f0c771a6f5e0d9ac6d769a28193a8025905a945c84eae5f11a1a1cbf6L179-R188): Adjusted the `Formatter` implementation to correctly handle single-line mode and skipping logic, ensuring that `pending_blank` is managed appropriately.

Enhancements to test coverage:

* [`efmt_core/src/items/macros.rs`](diffhunk://#diff-a50aa23e35231efb90aef27a018c4821b786851bd41c227ec7fd8c4c6aa8d6f9L621-R634): Updated the `assert_match` test to include multiple scenarios, improving the robustness of macro formatting tests.