### PR TITLE
Remove extra newlines between `-doc` attributes and function definitions

### DIFF
--- a/efmt_core/src/items.rs
+++ b/efmt_core/src/items.rs
@@ -42,8 +42,11 @@ impl Form {
         &self.0
     }
 
-    pub(crate) fn is_func_spec(&self) -> bool {
-        matches!(self.0, self::forms::Form::FunSpec(_))
+    pub(crate) fn is_func_spec_or_doc(&self) -> bool {
+        matches!(
+            self.0,
+            self::forms::Form::FunSpec(_) | self::forms::Form::Doc(_)
+        )
     }
 
     pub(crate) fn is_func_decl(&self) -> bool {

--- a/efmt_core/src/items/atoms.rs
+++ b/efmt_core/src/items/atoms.rs
@@ -62,3 +62,7 @@ impl_parse!(ExportTypeAtom, "export_type");
 #[derive(Debug, Clone, Span, Format, Element)]
 pub struct ModuleAtom(AtomToken);
 impl_parse!(ModuleAtom, "module");
+
+#[derive(Debug, Clone, Span, Format, Element)]
+pub struct DocAtom(AtomToken);
+impl_parse!(DocAtom, "doc");

--- a/efmt_core/src/items/module.rs
+++ b/efmt_core/src/items/module.rs
@@ -68,7 +68,7 @@ impl<const ALLOW_PARTIAL_FAILURE: bool> Parse for Module<ALLOW_PARTIAL_FAILURE> 
 impl<const ALLOW_PARTIAL_FAILURE: bool> Format for Module<ALLOW_PARTIAL_FAILURE> {
     fn format(&self, fmt: &mut Formatter) {
         let mut state = FormatState {
-            is_last_spec: false,
+            is_last_spec_or_doc: false,
             pending_constants: Vec::new(),
         };
         let mut is_last_fun_decl = false;
@@ -108,7 +108,7 @@ impl<const ALLOW_PARTIAL_FAILURE: bool> Format for Module<ALLOW_PARTIAL_FAILURE>
 }
 
 struct FormatState<'a> {
-    is_last_spec: bool,
+    is_last_spec_or_doc: bool,
     pending_constants: Vec<&'a DefineDirective>,
 }
 
@@ -168,16 +168,16 @@ impl<'a> FormatState<'a> {
     }
 
     fn insert_two_empty_newlines_if_need(&mut self, fmt: &mut Formatter, form: &'a Form) {
-        if form.is_func_decl() && !self.is_last_spec {
+        if form.is_func_decl() && !self.is_last_spec_or_doc {
             fmt.flush_non_preceding_comments(form);
             fmt.write_newlines(3);
         }
 
-        self.is_last_spec = form.is_func_spec();
-        if form.is_func_spec() {
+        if form.is_func_spec_or_doc() && !self.is_last_spec_or_doc {
             fmt.flush_non_preceding_comments(form);
             fmt.write_newlines(3);
         }
+        self.is_last_spec_or_doc = form.is_func_spec_or_doc();
     }
 }
 

--- a/tests/testdata/doc.erl
+++ b/tests/testdata/doc.erl
@@ -1,0 +1,10 @@
+%%---10--|----20---|----30---|----40---|----50---|
+-doc "Adds two number together".
+-doc #{since => "1.0", author => "Joe"}.
+-doc #{since => "2.0"}.
+add(One, Two) -> One + Two.
+
+
+-doc #{equiv => add(One, Two, [])}.
+-spec add(One :: number(), Two :: number()) -> number().
+add(One, Two) -> add(One, Two, []).

--- a/tests/testdata/long_spec.erl
+++ b/tests/testdata/long_spec.erl
@@ -5,12 +5,10 @@
 -spec foo(#bar{}, #baz{}) ->
           {ok, #quz{}} | {error, term()}.
 
-
 -spec bar(#bar{}, #baz{}) ->
           {ok, #quz{}} |
           {error, term()} |
           undefined.
-
 
 -spec baz() ->
           {ok, term()} | {error, Reason} | timeout

--- a/tests/testdata/otp27_strings.erl
+++ b/tests/testdata/otp27_strings.erl
@@ -1,12 +1,11 @@
 -module(otp27_strings).
 
+
 -doc """
     First line
     Second line with "\*not emphasized\* Markdown"
     Third line
     """.
-
-
 triple_quoted_strings() ->
     X = <<"""
         Line 1


### PR DESCRIPTION
Resolves https://github.com/sile/efmt/issues/109

Copilot Summary
------------------

This pull request introduces support for handling documentation attributes in the Erlang formatter. The changes mainly involve adding a new `Doc` attribute type and updating the formatting logic to accommodate it.

### Support for Documentation Attributes

* [`efmt_core/src/items/forms.rs`](diffhunk://#diff-540541c1464efd6fd8b0c0bfdea384a4607e1cd9cc30611ba0f25e876eb908d8R37): Added `Doc` to the `Form` enum and implemented the `Format` trait for it. Also, added the `DocAttr` struct to represent the documentation attribute. [[1]](diffhunk://#diff-540541c1464efd6fd8b0c0bfdea384a4607e1cd9cc30611ba0f25e876eb908d8R37) [[2]](diffhunk://#diff-540541c1464efd6fd8b0c0bfdea384a4607e1cd9cc30611ba0f25e876eb908d8R52) [[3]](diffhunk://#diff-540541c1464efd6fd8b0c0bfdea384a4607e1cd9cc30611ba0f25e876eb908d8R469-R474)
* [`efmt_core/src/items.rs`](diffhunk://#diff-4bb4a38f31620c6d54169c4b28d8f6c83403fd75b3ca819a3c9706834c6524deL45-R49): Updated the `is_func_spec` method to `is_func_spec_or_doc` to include the new `Doc` attribute.
* [`efmt_core/src/items/module.rs`](diffhunk://#diff-0da6858cf46ead7b402c0ba11a55825127177d163d1bfaea0cb249f3d13798a5L71-R71): Modified the `FormatState` struct and related logic to handle the new `Doc` attribute. [[1]](diffhunk://#diff-0da6858cf46ead7b402c0ba11a55825127177d163d1bfaea0cb249f3d13798a5L71-R71) [[2]](diffhunk://#diff-0da6858cf46ead7b402c0ba11a55825127177d163d1bfaea0cb249f3d13798a5L111-R111) [[3]](diffhunk://#diff-0da6858cf46ead7b402c0ba11a55825127177d163d1bfaea0cb249f3d13798a5L171-R180)

### Parsing and Atoms

* [`efmt_core/src/items/atoms.rs`](diffhunk://#diff-da3e9715829fc11c44056089461f097f811ad444745b633a28e917552f74f697R65-R68): Added a new `DocAtom` struct and implemented parsing for it.
* [`efmt_core/src/items/forms.rs`](diffhunk://#diff-540541c1464efd6fd8b0c0bfdea384a4607e1cd9cc30611ba0f25e876eb908d8R2): Imported `DocAtom` to use in the `DocAttr` struct.

### Tests

* [`efmt_core/src/items/forms.rs`](diffhunk://#diff-540541c1464efd6fd8b0c0bfdea384a4607e1cd9cc30611ba0f25e876eb908d8R859-R872): Added tests to ensure the `Doc` attribute is correctly parsed and formatted.
* [`tests/testdata/doc.erl`](diffhunk://#diff-aac4a00b0b9de437a4e4b4c658a4b827673ee2b75ef59692a8c6c78e383de502R1-R10): Added test cases for the `Doc` attribute.
* `tests/testdata/long_spec.erl` and `tests/testdata/otp27_strings.erl`: Minor adjustments to existing test data files. [[1]](diffhunk://#diff-de18b190ebe87d589cb380b24e05d77dfa599b44f99fd4198cc6b92e74f89ea9L8-L14) [[2]](diffhunk://#diff-d398a63b27326858e39a94f27305e17cdfe80f355f59c9e2e78e2fce30b1e68bR3-L9)