### PR TITLE
Insert a blank line between `-include` and `-include_lib`

### DIFF
--- a/efmt_core/src/items.rs
+++ b/efmt_core/src/items.rs
@@ -52,6 +52,14 @@ impl Form {
     pub(crate) fn is_func_decl(&self) -> bool {
         matches!(self.0, self::forms::Form::FunDecl(_))
     }
+
+    pub(crate) fn is_include_lib(&self) -> Option<bool> {
+        if let self::forms::Form::Include(x) = &self.0 {
+            Some(x.is_include_lib())
+        } else {
+            None
+        }
+    }
 }
 
 /// One of [types].

--- a/efmt_core/src/items/module.rs
+++ b/efmt_core/src/items/module.rs
@@ -72,6 +72,7 @@ impl<const ALLOW_PARTIAL_FAILURE: bool> Format for Module<ALLOW_PARTIAL_FAILURE>
             pending_constants: Vec::new(),
         };
         let mut is_last_fun_decl = false;
+        let mut is_last_include_lib = None;
 
         for form in &self.forms {
             if is_last_fun_decl {
@@ -88,6 +89,13 @@ impl<const ALLOW_PARTIAL_FAILURE: bool> Format for Module<ALLOW_PARTIAL_FAILURE>
                 }
             };
 
+            match (is_last_include_lib.take(), form.is_include_lib()) {
+                (Some(a), Some(b)) if a != b => {
+                    fmt.write_newlines(2);
+                }
+                _ => {}
+            }
+
             if state.pend_if_need(fmt, form) {
                 continue;
             }
@@ -101,6 +109,7 @@ impl<const ALLOW_PARTIAL_FAILURE: bool> Format for Module<ALLOW_PARTIAL_FAILURE>
             form.format(fmt);
             fmt.write_newline();
             is_last_fun_decl = form.is_func_decl();
+            is_last_include_lib = form.is_include_lib();
         }
 
         state.flush_pendings(fmt);

--- a/tests/testdata/include.erl
+++ b/tests/testdata/include.erl
@@ -1,0 +1,7 @@
+-module(include).
+
+-include_lib("foo/foo.hrl").
+-include_lib("bar/bar.hrl").
+
+-include("baz.hrl").
+-include("qux.hrl").


### PR DESCRIPTION
Copilot Summary
---

This pull request introduces functionality to handle `include_lib` forms in the formatting process. The changes include adding a method to identify `include_lib` forms, updating the formatting logic to handle these forms, and adding a test case to verify the new functionality.

Enhancements to form handling:

* [`efmt_core/src/items.rs`](diffhunk://#diff-4bb4a38f31620c6d54169c4b28d8f6c83403fd75b3ca819a3c9706834c6524deR55-R62): Added the `is_include_lib` method to the `Form` struct to identify `include_lib` forms.

Updates to formatting logic:

* [`efmt_core/src/items/module.rs`](diffhunk://#diff-0da6858cf46ead7b402c0ba11a55825127177d163d1bfaea0cb249f3d13798a5R75): Introduced the `is_last_include_lib` variable to track the last `include_lib` form and modified the formatting logic to insert newlines between different `include_lib` forms. [[1]](diffhunk://#diff-0da6858cf46ead7b402c0ba11a55825127177d163d1bfaea0cb249f3d13798a5R75) [[2]](diffhunk://#diff-0da6858cf46ead7b402c0ba11a55825127177d163d1bfaea0cb249f3d13798a5R92-R98) [[3]](diffhunk://#diff-0da6858cf46ead7b402c0ba11a55825127177d163d1bfaea0cb249f3d13798a5R112)

Testing:

* [`tests/testdata/include.erl`](diffhunk://#diff-df7c5325bc03c3748e6be83671c5ec8a4742d7c6cc08f703ad08406a37cec7a3R1-R7): Added a new test file to verify the correct formatting of `include_lib` forms.