### PR TITLE
Add support for EEP-69 (Nominal Type)

### DIFF
--- a/efmt_core/src/items/atoms.rs
+++ b/efmt_core/src/items/atoms.rs
@@ -44,6 +44,10 @@ pub struct OpaqueAtom(AtomToken);
 impl_parse!(OpaqueAtom, "opaque");
 
 #[derive(Debug, Clone, Span, Format, Element)]
+pub struct NominalAtom(AtomToken);
+impl_parse!(NominalAtom, "nominal");
+
+#[derive(Debug, Clone, Span, Format, Element)]
 pub struct CallbackAtom(AtomToken);
 impl_parse!(CallbackAtom, "callback");
 

--- a/efmt_core/src/items/forms.rs
+++ b/efmt_core/src/items/forms.rs
@@ -1,5 +1,5 @@
 //! Erlang top-level components such as attributes, directives or declarations.
-use super::atoms::DocAtom;
+use super::atoms::{DocAtom, NominalAtom};
 use super::components::Guard;
 use super::symbols::RightArrowSymbol;
 use crate::format::{Format, Formatter};
@@ -166,7 +166,7 @@ impl TypeDecl {
     }
 }
 
-type TypeDeclName = Either<TypeAtom, OpaqueAtom>;
+type TypeDeclName = Either<TypeAtom, Either<OpaqueAtom, NominalAtom>>;
 
 #[derive(Debug, Clone, Span, Parse)]
 struct TypeDeclItem {
@@ -852,6 +852,11 @@ mod tests {
                             Val) ::
                       [{Key,
                         Val}]."},
+            indoc::indoc! {"
+            -nominal orddict(Key,
+                             Val) ::
+                       [{Key,
+                         Val}]."},
         ];
         for text in texts {
             crate::assert_format!(text, Form);


### PR DESCRIPTION
Copilot Summary 
---


This pull request introduces a new `NominalAtom` type to the `efmt_core` module and updates related components to support it. The most important changes include adding the `NominalAtom` struct, updating type declarations, and modifying test cases to include the new type.

### Addition of `NominalAtom` type:

* [`efmt_core/src/items/atoms.rs`](diffhunk://#diff-da3e9715829fc11c44056089461f097f811ad444745b633a28e917552f74f697R46-R49): Added the `NominalAtom` struct and implemented parsing for it.

### Updates to type declarations:

* [`efmt_core/src/items/forms.rs`](diffhunk://#diff-540541c1464efd6fd8b0c0bfdea384a4607e1cd9cc30611ba0f25e876eb908d8L2-R2): Imported `NominalAtom` and updated the `TypeDeclName` type to include `NominalAtom`. [[1]](diffhunk://#diff-540541c1464efd6fd8b0c0bfdea384a4607e1cd9cc30611ba0f25e876eb908d8L2-R2) [[2]](diffhunk://#diff-540541c1464efd6fd8b0c0bfdea384a4607e1cd9cc30611ba0f25e876eb908d8L169-R169)

### Test updates:

* [`efmt_core/src/items/forms.rs`](diffhunk://#diff-540541c1464efd6fd8b0c0bfdea384a4607e1cd9cc30611ba0f25e876eb908d8R855-R859): Added a new test case for the `NominalAtom` type.