### PR TITLE
Add support for strict comprehensions generators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "erl_tokenize"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ff8728d7851d634bb06fe3566d461086676efeed23f95d7b5ce16f192dcd6d"
+checksum = "781975a7f3d7f05990eefe08630d82873fbd5f18e83b51487ff9967811dc8d51"
 dependencies = [
  "num-bigint",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["/rebar3_efmt/", "efmt_wasm.wasm", "/vscode/"]
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-erl_tokenize = "0.7"
+erl_tokenize = "0.8"
 efmt_core = { path = "efmt_core", version = "0.4.0" }
 env_logger = "0.11"
 log = "0.4"

--- a/efmt_core/Cargo.toml
+++ b/efmt_core/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/sile/efmt"
 readme = "README.md"
 
 [dependencies]
-erl_tokenize = "0.7"
+erl_tokenize = "0.8"
 efmt_derive = { path = "../efmt_derive", version = "0.1.0" }
 log = "0.4"
 

--- a/efmt_core/src/items/expressions/bitstrings.rs
+++ b/efmt_core/src/items/expressions/bitstrings.rs
@@ -170,7 +170,7 @@ mod tests {
                      true ->
                          X - 10 + $A
                  end>>
-               || <<X:4>> <= B >>"},
+               || <<X:4>> <:= B >>"},
         ];
         for text in texts {
             crate::assert_format!(text, Expr);

--- a/efmt_core/src/items/expressions/components.rs
+++ b/efmt_core/src/items/expressions/components.rs
@@ -3,7 +3,7 @@ use crate::items::components::{Either, Guard, Maybe, NonEmptyItems, Params};
 use crate::items::keywords;
 use crate::items::symbols::{
     self, CommaSymbol, DoubleLeftArrowSymbol, DoubleVerticalBarSymbol, LeftArrowSymbol,
-    MapMatchSymbol, RightArrowSymbol,
+    MapMatchSymbol, RightArrowSymbol, StrictDoubleLeftArrowSymbol, StrictLeftArrowSymbol,
 };
 use crate::items::tokens::LexicalToken;
 use crate::items::Expr;
@@ -188,7 +188,12 @@ impl Format for Generator {
 }
 
 #[derive(Debug, Clone, Span, Parse, Format)]
-struct GeneratorDelimiter(Either<LeftArrowSymbol, DoubleLeftArrowSymbol>);
+struct GeneratorDelimiter(
+    Either<
+        Either<LeftArrowSymbol, DoubleLeftArrowSymbol>,
+        Either<StrictLeftArrowSymbol, StrictDoubleLeftArrowSymbol>,
+    >,
+);
 
 #[derive(Debug, Clone, Span, Parse)]
 pub(crate) struct ComprehensionExpr<Open, Close, Value = Expr> {

--- a/efmt_core/src/items/expressions/lists.rs
+++ b/efmt_core/src/items/expressions/lists.rs
@@ -128,6 +128,8 @@ mod tests {
                        4, 5],
                  Y <= Z,
                  false ]"},
+            indoc::indoc! {"
+            [ X || X <:- [1, 2] ]"},
         ];
         for text in texts {
             crate::assert_format!(text, Expr);

--- a/efmt_core/src/items/expressions/maps.rs
+++ b/efmt_core/src/items/expressions/maps.rs
@@ -122,6 +122,7 @@ mod tests {
         let texts = [
             "#{ Key => Value || Key := Value <- MapOrIterator }",
             "#{ K => V || <<K, V>> <= Binary }",
+            "#{ K => V || <<K, V>> <:= Binary }",
         ];
         for text in texts {
             crate::assert_format!(text, Expr);

--- a/efmt_core/src/items/symbols.rs
+++ b/efmt_core/src/items/symbols.rs
@@ -147,6 +147,10 @@ pub struct DoubleRightArrowSymbol(SymbolToken);
 impl_traits!(DoubleRightArrowSymbol, DoubleRightArrow);
 
 #[derive(Debug, Clone, Span, Format)]
+pub struct StrictLeftArrowSymbol(SymbolToken);
+impl_traits!(StrictLeftArrowSymbol, StrictLeftArrow);
+
+#[derive(Debug, Clone, Span, Format)]
 pub struct DoubleLeftArrowSymbol(SymbolToken);
 impl_traits!(DoubleLeftArrowSymbol, DoubleLeftArrow);
 
@@ -157,6 +161,10 @@ impl_traits!(DoubleRightAngleSymbol, DoubleRightAngle);
 #[derive(Debug, Clone, Span, Format)]
 pub struct DoubleLeftAngleSymbol(SymbolToken);
 impl_traits!(DoubleLeftAngleSymbol, DoubleLeftAngle);
+
+#[derive(Debug, Clone, Span, Format)]
+pub struct StrictDoubleLeftArrowSymbol(SymbolToken);
+impl_traits!(StrictDoubleLeftArrowSymbol, StrictDoubleLeftArrow);
 
 #[derive(Debug, Clone, Span, Format)]
 pub struct EqSymbol(SymbolToken);


### PR DESCRIPTION
https://github.com/erlang/otp/releases/tag/OTP-28.0-rc1

Copilot Summary 
---

This pull request includes several changes to update dependencies, add new symbols, and modify tests in the `efmt` project. The most important changes are grouped by theme below:

Dependency Updates:
* Updated `erl_tokenize` dependency from version `0.7` to `0.8` in `Cargo.toml` and `efmt_core/Cargo.toml`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L16-R16) [[2]](diffhunk://#diff-3fd8060277d6a47bfdc905c5f2124208b248926d3eefdd24dd47b02bee172265L13-R13)

New Symbols:
* Added `StrictLeftArrowSymbol` and `StrictDoubleLeftArrowSymbol` to `efmt_core/src/items/symbols.rs`. [[1]](diffhunk://#diff-571d7ba226cb30e3621ec2ed6d2dc95f17fe61271f8e9cc52fd4a11b396f004dR149-R152) [[2]](diffhunk://#diff-571d7ba226cb30e3621ec2ed6d2dc95f17fe61271f8e9cc52fd4a11b396f004dR165-R168)
* Modified `GeneratorDelimiter` struct to include the new `StrictLeftArrowSymbol` and `StrictDoubleLeftArrowSymbol` in `efmt_core/src/items/expressions/components.rs`.

Test Modifications:
* Updated test cases to include the new `StrictLeftArrowSymbol` in `efmt_core/src/items/expressions/bitstrings.rs`, `efmt_core/src/items/expressions/lists.rs`, and `efmt_core/src/items/expressions/maps.rs`. [[1]](diffhunk://#diff-2dd78c77a61358e036fd3d4689a3d2fff6d486fa49d0d897d24683af1515ffa7L173-R173) [[2]](diffhunk://#diff-621954d558c9eac9fa6ec09c3a4a7d644380670f5997b4900470aa06a930f0a6R131-R132) [[3]](diffhunk://#diff-481712679ac1030fa6fe8350698e8607b55d77ae6162a82070aa07dc09fce85bR125)