### PR TITLE
Add support for EEP 73 (Zip generator)

### DIFF
--- a/efmt_core/src/items/expressions/components.rs
+++ b/efmt_core/src/items/expressions/components.rs
@@ -2,8 +2,9 @@ use crate::format::{Format, Formatter};
 use crate::items::components::{Either, Guard, Maybe, NonEmptyItems, Params};
 use crate::items::keywords;
 use crate::items::symbols::{
-    self, CommaSymbol, DoubleLeftArrowSymbol, DoubleVerticalBarSymbol, LeftArrowSymbol,
-    MapMatchSymbol, RightArrowSymbol, StrictDoubleLeftArrowSymbol, StrictLeftArrowSymbol,
+    self, CommaSymbol, DoubleAmpersandSymbol, DoubleLeftArrowSymbol, DoubleVerticalBarSymbol,
+    LeftArrowSymbol, MapMatchSymbol, RightArrowSymbol, StrictDoubleLeftArrowSymbol,
+    StrictLeftArrowSymbol,
 };
 use crate::items::tokens::LexicalToken;
 use crate::items::Expr;
@@ -123,13 +124,12 @@ impl Format for Body {
 /// - $GENERATOR: (`Expr` | `Expr` `:=` `Expr`) (`<-` | `<:-`) `Expr` | `Expr` (`<=` | `<:=`) `Expr` (`&&` $GENERATOR)?
 /// - $FILTER: `Expr`
 #[derive(Debug, Clone, Span, Parse, Format)]
-pub struct Qualifier(Either<Either<ZipGenerator, Generator>, Expr>);
+pub struct Qualifier(Either<Generator, Expr>);
 
 impl Qualifier {
     pub fn children(&self) -> impl Iterator<Item = &Expr> {
         match &self.0 {
-            Either::A(Either::A(x)) => Either::A(Either::A(x.children())),
-            Either::A(Either::B(x)) => Either::A(Either::B(x.children())),
+            Either::A(x) => Either::A(x.children()),
             Either::B(x) => Either::B(std::iter::once(x)),
         }
     }
@@ -163,6 +163,7 @@ struct Generator {
     pattern: Either<MapGeneratorPattern, Expr>,
     delimiter: GeneratorDelimiter,
     sequence: Expr,
+    zip: Maybe<(DoubleAmpersandSymbol, Box<Self>)>,
 }
 
 impl Generator {
@@ -171,7 +172,9 @@ impl Generator {
             Either::A(x) => Either::A(x.children()),
             Either::B(x) => Either::B(std::iter::once(x)),
         };
+        let zip_iter = self.zip.get().into_iter().flat_map(|x| x.1.children());
         iter.chain(std::iter::once(&self.sequence))
+            .chain(Box::new(zip_iter) as Box<dyn Iterator<Item = &Expr>>)
     }
 }
 
@@ -185,6 +188,17 @@ impl Format for Generator {
             fmt.set_indent(fmt.column());
             self.sequence.format(fmt);
         });
+        if let Some((delimiter, zipped)) = self.zip.get() {
+            let multiline = fmt.has_newline_until(zipped);
+            fmt.write_space();
+            delimiter.format(fmt);
+            if multiline {
+                fmt.write_newline();
+            } else {
+                fmt.write_space();
+            }
+            zipped.format(fmt);
+        }
     }
 }
 

--- a/efmt_core/src/items/expressions/components.rs
+++ b/efmt_core/src/items/expressions/components.rs
@@ -176,10 +176,8 @@ impl Generator {
         iter.chain(std::iter::once(&self.sequence))
             .chain(Box::new(zip_iter) as Box<dyn Iterator<Item = &Expr>>)
     }
-}
 
-impl Format for Generator {
-    fn format(&self, fmt: &mut Formatter) {
+    fn format_generator(&self, fmt: &mut Formatter, multiline: bool) {
         fmt.with_scoped_indent(|fmt| {
             self.pattern.format(fmt);
             fmt.write_space();
@@ -189,7 +187,6 @@ impl Format for Generator {
             self.sequence.format(fmt);
         });
         if let Some((delimiter, zipped)) = self.zip.get() {
-            let multiline = fmt.has_newline_until(zipped);
             fmt.write_space();
             delimiter.format(fmt);
             if multiline {
@@ -199,6 +196,13 @@ impl Format for Generator {
             }
             zipped.format(fmt);
         }
+    }
+}
+
+impl Format for Generator {
+    fn format(&self, fmt: &mut Formatter) {
+        let multiline = fmt.has_newline_until(&self.end_position());
+        self.format_generator(fmt, multiline);
     }
 }
 

--- a/efmt_core/src/items/expressions/components.rs
+++ b/efmt_core/src/items/expressions/components.rs
@@ -120,15 +120,16 @@ impl Format for Body {
 }
 
 /// ((`$GENERATOR` | `$FILTER`) `,`?)+
-/// - $GENERATOR: (`Expr` | `Expr` `:=` `Expr`) `<-` `Expr` | `Expr` `<=` `Expr`
+/// - $GENERATOR: (`Expr` | `Expr` `:=` `Expr`) (`<-` | `<:-`) `Expr` | `Expr` (`<=` | `<:=`) `Expr` (`&&` $GENERATOR)?
 /// - $FILTER: `Expr`
 #[derive(Debug, Clone, Span, Parse, Format)]
-pub struct Qualifier(Either<Generator, Expr>);
+pub struct Qualifier(Either<Either<ZipGenerator, Generator>, Expr>);
 
 impl Qualifier {
     pub fn children(&self) -> impl Iterator<Item = &Expr> {
         match &self.0 {
-            Either::A(x) => Either::A(x.children()),
+            Either::A(Either::A(x)) => Either::A(Either::A(x.children())),
+            Either::A(Either::B(x)) => Either::A(Either::B(x.children())),
             Either::B(x) => Either::B(std::iter::once(x)),
         }
     }

--- a/efmt_core/src/items/expressions/lists.rs
+++ b/efmt_core/src/items/expressions/lists.rs
@@ -130,6 +130,15 @@ mod tests {
                  false ]"},
             indoc::indoc! {"
             [ X || X <:- [1, 2] ]"},
+            indoc::indoc! {"
+            [ X || X <:- [1, 2] && Y <:- Z,
+                   is_integer(Y) ]"},
+            indoc::indoc! {"
+            [ [X, Y]
+              || X <- [1, 2, 3,
+                       4, 5] &&
+                 Y <- [0, 9, 2],
+                 Y <= X ]"},
         ];
         for text in texts {
             crate::assert_format!(text, Expr);

--- a/efmt_core/src/items/forms.rs
+++ b/efmt_core/src/items/forms.rs
@@ -142,7 +142,7 @@ impl Format for RecordField {
     }
 }
 
-/// `-` (`type` | `opaque`) `$NAME` `(` (`$PARAM` `,`?)* `)` `::` `$TYPE` `.`
+/// `-` (`type` | `opaque` | `nominal`) `$NAME` `(` (`$PARAM` `,`?)* `)` `::` `$TYPE` `.`
 ///
 /// - $NAME: [AtomToken]
 /// - $PARAM: [VariableToken]

--- a/efmt_core/src/items/symbols.rs
+++ b/efmt_core/src/items/symbols.rs
@@ -80,6 +80,10 @@ pub struct SemicolonSymbol(SymbolToken);
 impl_traits!(SemicolonSymbol, Semicolon);
 
 #[derive(Debug, Clone, Span, Format)]
+pub struct DoubleAmpersandSymbol(SymbolToken);
+impl_traits!(DoubleAmpersandSymbol, DoubleAmpersand);
+
+#[derive(Debug, Clone, Span, Format)]
 pub struct MatchSymbol(SymbolToken);
 impl_traits!(MatchSymbol, Match);
 


### PR DESCRIPTION
Copilot Summary 
---

This pull request includes several changes to the `efmt_core` module to enhance the formatting capabilities and add support for new syntax elements. The most important changes include the addition of a new symbol, updates to the generator formatting logic, and new test cases.

### Enhancements to formatting capabilities:

* Added `DoubleAmpersandSymbol` to `symbols` module to support new syntax elements. (`efmt_core/src/items/symbols.rs`)

### Updates to generator formatting:

* Modified the `Generator` struct to include the `zip` field for handling zipped generators. (`efmt_core/src/items/expressions/components.rs`)
* Updated the `format_generator` method to handle the new `zip` field and format it appropriately based on whether the output should be multiline. (`efmt_core/src/items/expressions/components.rs`)

### New test cases:

* Added test cases to cover the new generator syntax with `DoubleAmpersandSymbol` in the `lists` module. (`efmt_core/src/items/expressions/lists.rs`)

### Other changes:

* Updated the `Qualifier` struct documentation to reflect the new generator syntax. (`efmt_core/src/items/expressions/components.rs`)
* Extended the `RecordField` documentation to include the new `nominal` type. (`efmt_core/src/items/forms.rs`)