### PR TITLE
Add `Tokenizer::set_position()`

### DIFF
--- a/efmt_core/src/parse/tokenizer.rs
+++ b/efmt_core/src/parse/tokenizer.rs
@@ -35,6 +35,10 @@ impl Tokenizer {
         self.inner.next_position()
     }
 
+    pub fn set_position(&mut self, position: Position) {
+        self.inner.set_position(position);
+    }
+
     pub fn set_filepath<P: AsRef<Path>>(&mut self, path: P) {
         self.inner.set_filepath(path)
     }


### PR DESCRIPTION
Copilot Summary
-------------------

This pull request includes a new method to set the position in the `Tokenizer` implementation. The most important change is the addition of the `set_position` method to the `Tokenizer` class in the `efmt_core/src/parse/tokenizer.rs` file.

Enhancements to `Tokenizer`:

* [`efmt_core/src/parse/tokenizer.rs`](diffhunk://#diff-dd5a5ca710ddc21222c154b3081453233f76c741f874d3a371b70693132f4056R38-R41): Added `set_position` method to allow setting the tokenizer's position.