### PR TITLE
Update `erl_tokenize` version to 0.8.1 (fixed float tokenize bug)  

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,9 +258,9 @@ dependencies = [
 
 [[package]]
 name = "erl_tokenize"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781975a7f3d7f05990eefe08630d82873fbd5f18e83b51487ff9967811dc8d51"
+checksum = "5a706779df2ad15c359ee03cd71e234816ecfb5b937fab52a44b8f37d98c35b9"
 dependencies = [
  "num-bigint",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["/rebar3_efmt/", "efmt_wasm.wasm", "/vscode/"]
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-erl_tokenize = "0.8"
+erl_tokenize = "0.8.1"
 efmt_core = { path = "efmt_core", version = "0.5.0" }
 env_logger = "0.11"
 log = "0.4"

--- a/efmt_core/Cargo.toml
+++ b/efmt_core/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/sile/efmt"
 readme = "README.md"
 
 [dependencies]
-erl_tokenize = "0.8"
+erl_tokenize = "0.8.1"
 efmt_derive = { path = "../efmt_derive", version = "0.1.0" }
 log = "0.4"
 


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes updates to the `erl_tokenize` dependency version in the `Cargo.toml` files for both the main project and the `efmt_core` crate.

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L16-R16): Updated `erl_tokenize` dependency from version `0.8` to `0.8.1`.
* [`efmt_core/Cargo.toml`](diffhunk://#diff-3fd8060277d6a47bfdc905c5f2124208b248926d3eefdd24dd47b02bee172265L13-R13): Updated `erl_tokenize` dependency from version `0.8` to `0.8.1`.