### PR TITLE
Remove rayon dependency and replace with std::thread-based parallelization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,6 @@ dependencies = [
  "ignore",
  "log",
  "noargs",
- "rayon",
  "regex",
  "similar",
  "similar-asserts",
@@ -111,12 +110,6 @@ version = "0.1.0"
 dependencies = [
  "efmt_core",
 ]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -214,26 +207,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ exclude = ["/rebar3_efmt/", "efmt_wasm.wasm", "/vscode/"]
 erl_tokenize = "0.10.0"
 efmt_core = { path = "efmt_core", version = "0.7.0" }
 log = "0.4"
-rayon = "1"
 similar = { version= "2", features = ["inline"] }
 regex = "1.6.0"
 colored = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -404,13 +404,10 @@ where
         .min(files.len());
     let next_index = AtomicUsize::new(0);
     let (sender, receiver) = std::sync::mpsc::channel::<usize>();
-    let next_index = &next_index;
-    let predicate = &predicate;
 
     std::thread::scope(|scope| {
         for _ in 0..workers {
-            let sender = sender.clone();
-            scope.spawn(move || {
+            scope.spawn(|| {
                 loop {
                     let index = next_index.fetch_add(1, Ordering::Relaxed);
                     if index >= files.len() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
 use efmt::files::RebarConfigValue;
 use efmt_core::items::ModuleOrConfig;
-use rayon::iter::{IntoParallelIterator as _, ParallelIterator};
 use regex::Regex;
 use std::io::Read as _;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use unicode_width::UnicodeWidthStr;
 
 type Result<T> = efmt::Result<T>;
@@ -369,6 +370,69 @@ fn format_file_or_stdin<P: AsRef<Path>>(
     Ok((original, formatted))
 }
 
+fn contains_stdin_path(files: &[PathBuf]) -> bool {
+    files.iter().any(|file| file.to_str() == Some("-"))
+}
+
+fn should_run_in_parallel(files: &[PathBuf], requested_parallel: bool) -> bool {
+    if !requested_parallel {
+        return false;
+    }
+    if contains_stdin_path(files) {
+        log::warn!("parallel execution is disabled when input contains '-' (stdin)");
+        return false;
+    }
+    true
+}
+
+fn filter_target_files<F>(files: &[PathBuf], parallel: bool, predicate: F) -> Vec<PathBuf>
+where
+    F: Fn(&Path) -> bool + Sync,
+{
+    if !parallel || files.len() <= 1 {
+        return files
+            .iter()
+            .filter(|file| predicate(file))
+            .cloned()
+            .collect::<Vec<_>>();
+    }
+
+    let workers = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+        .min(files.len());
+    let next_index = AtomicUsize::new(0);
+    let selected_indices = Mutex::new(Vec::new());
+
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            scope.spawn(|| {
+                loop {
+                    let index = next_index.fetch_add(1, Ordering::Relaxed);
+                    if index >= files.len() {
+                        break;
+                    }
+                    if predicate(&files[index]) {
+                        selected_indices
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner())
+                            .push(index);
+                    }
+                }
+            });
+        }
+    });
+
+    let mut selected_indices = selected_indices
+        .into_inner()
+        .unwrap_or_else(|e| e.into_inner());
+    selected_indices.sort_unstable();
+    selected_indices
+        .into_iter()
+        .map(|index| files[index].clone())
+        .collect::<Vec<_>>()
+}
+
 fn format_files(opt: &Opt) -> crate::Result<()> {
     let format_options = opt.to_format_options();
 
@@ -399,19 +463,10 @@ fn format_files(opt: &Opt) -> crate::Result<()> {
         }
     }
 
-    let error_files = if opt.parallel {
-        opt.files
-            .clone()
-            .into_par_iter()
-            .filter(|file| do_format(opt, &format_options, file).is_err())
-            .collect::<Vec<_>>()
-    } else {
-        opt.files
-            .iter()
-            .filter(|file| do_format(opt, &format_options, file).is_err())
-            .cloned()
-            .collect::<Vec<_>>()
-    };
+    let run_parallel = should_run_in_parallel(&opt.files, opt.parallel);
+    let error_files = filter_target_files(&opt.files, run_parallel, |file| {
+        do_format(opt, &format_options, file).is_err()
+    });
 
     if !error_files.is_empty() {
         if opt.files.len() > 1 {
@@ -504,35 +559,16 @@ fn check_files(opt: &Opt) -> crate::Result<()> {
         }
     }
 
-    let unformatted_files = if opt.parallel {
-        opt.files
-            .clone()
-            .into_par_iter()
-            .filter(|file| {
-                !do_check(
-                    &format_options,
-                    file,
-                    opt.allow_partial_failure,
-                    opt.color,
-                    opt.check_line_length,
-                )
-            })
-            .collect::<Vec<_>>()
-    } else {
-        opt.files
-            .iter()
-            .filter(|file| {
-                !do_check(
-                    &format_options,
-                    file,
-                    opt.allow_partial_failure,
-                    opt.color,
-                    opt.check_line_length,
-                )
-            })
-            .cloned()
-            .collect::<Vec<_>>()
-    };
+    let run_parallel = should_run_in_parallel(&opt.files, opt.parallel);
+    let unformatted_files = filter_target_files(&opt.files, run_parallel, |file| {
+        !do_check(
+            &format_options,
+            file,
+            opt.allow_partial_failure,
+            opt.color,
+            opt.check_line_length,
+        )
+    });
 
     if !unformatted_files.is_empty() {
         eprintln!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -385,6 +385,8 @@ fn should_run_in_parallel(files: &[PathBuf], requested_parallel: bool) -> bool {
     true
 }
 
+// `predicate` is shared by reference across worker threads when `parallel` is true,
+// so `F: Sync` is required.
 fn filter_target_files<F>(files: &[PathBuf], parallel: bool, predicate: F) -> Vec<PathBuf>
 where
     F: Fn(&Path) -> bool + Sync,


### PR DESCRIPTION
This PR removes the `rayon` crate dependency and replaces its parallel iteration functionality with a custom implementation using Rust's standard library `std::thread`. 

**Key changes:**
- Removed `rayon` and `either` from `Cargo.toml` and `Cargo.lock`
- Replaced `rayon::iter::IntoParallelIterator` with a custom `filter_target_files` function that uses `std::thread::scope` for manual thread pool management
- Added helper functions `contains_stdin_path` and `should_run_in_parallel` to handle parallel execution logic, including a warning when stdin is used with parallel mode
- Simplified parallel filtering in both `format_files` and `check_files` functions to use the new unified `filter_target_files` implementation
- Uses `AtomicUsize` and `Mutex` for thread-safe coordination without external dependencies

